### PR TITLE
Move error formatting into error definition.

### DIFF
--- a/dacpac/src/connection.rs
+++ b/dacpac/src/connection.rs
@@ -11,12 +11,16 @@ error_chain! {
         PostgresConnect(::postgres::error::ConnectError);
     }
     errors {
-        MalformedConnectionString
-        RequiredPartMissing(part: String) {
-            description("required connection string part missing")
-            display("required connection string part missing: '{}'", part)
+        MalformedConnectionString {
+            description("The connection string was malformed.")
         }
-        TlsNotSupported
+        RequiredPartMissing(part: String) {
+            description("Required connection string part missing")
+            display("Required connection string part missing: '{}'", part)
+        }
+        TlsNotSupported {
+            description("TLS connections are not currently supported.")
+        }
     }
 }
 

--- a/dacpac/src/dacpac.rs
+++ b/dacpac/src/dacpac.rs
@@ -112,7 +112,7 @@ impl Dacpac {
 
         // Start the project
         let mut project = Project::new();
-        let mut errors = Vec::new();
+        let mut errors: Vec<DacpacError> = Vec::new();
 
         // Enumerate the directory
         for entry in WalkDir::new(project_path.parent().unwrap()).follow_links(false) {
@@ -125,7 +125,7 @@ impl Dacpac {
 
             let mut contents = String::new();
             if let Err(err) = File::open(&path).and_then(|mut f| f.read_to_string(&mut contents)) {
-                errors.push(DacpacErrorKind::IOError(format!("{}", path.display()), format!("{}", err)));
+                errors.push(DacpacErrorKind::IOError(format!("{}", path.display()), format!("{}", err)).into());
                 continue;
             }
 
@@ -155,7 +155,7 @@ impl Dacpac {
                             e.line_number,
                             e.start_pos,
                             e.end_pos
-                        ));
+                        ).into());
                         continue;
                     },
                 };
@@ -173,7 +173,7 @@ impl Dacpac {
                         }
                     },
                     Err(err) => {
-                        errors.push(DacpacErrorKind::ParseError(format!("{}", path.display()), vec!(err)));
+                        errors.push(DacpacErrorKind::ParseError(format!("{}", path.display()), vec!(err)).into());
                         continue;
                     }
                 }

--- a/dacpac/src/errors.rs
+++ b/dacpac/src/errors.rs
@@ -1,4 +1,5 @@
-use lalrpop_util::ParseError;
+pub use error_chain::ChainedError;
+pub use lalrpop_util::ParseError;
 
 use lexer;
 use connection::{ConnectionError, ConnectionErrorKind};
@@ -11,13 +12,84 @@ error_chain! {
         Connection(ConnectionError, ConnectionErrorKind);
     }
     errors {
-        IOError(file: String, message: String)
-        SyntaxError(file: String, line: String, line_number: i32, start_pos: i32, end_pos: i32)
-        ParseError(file: String, errors: Vec<ParseError<(), lexer::Token, ()>>)
-        GenerationError(message: String)
-        FormatError(file: String, message: String)
-        DatabaseError(message: String)
-        ProjectError(message: String)
-        MultipleErrors(errors: Vec<DacpacErrorKind>)
+        IOError(file: String, message: String) {
+            description("IO error when reading a file")
+            display("IO error when reading {}: {}", file, message)
+        }
+        SyntaxError(file: String, line: String, line_number: i32, start_pos: i32, end_pos: i32) {
+            description("SQL syntax error encountered")
+            display(
+                "SQL syntax error encountered in {} on line {}:\n  {}\n  {}{}",
+                file, line_number, line, " ".repeat(*start_pos as usize), "^".repeat((end_pos - start_pos) as usize))
+        }
+        ParseError(file: String, errors: Vec<ParseError<(), lexer::Token, ()>>) {
+            description("Parser error")
+            display("Parser errors in {}:\n{}", file, ParseErrorFormatter(errors))
+        }
+        GenerationError(message: String) {
+            description("Error generating DACPAC")
+            display("Error generating DACPAC: {}", message)
+        }
+        FormatError(file: String, message: String) {
+            description("Format error when reading a file")
+            display("Format error when reading {}: {}", file, message)
+        }
+        DatabaseError(message: String) {
+            description("Database error")
+            display("Database error: {}", message)
+        }
+        ProjectError(message: String) {
+            description("Project format error")
+            display("Project format error: {}", message)
+        }
+        MultipleErrors(errors: Vec<DacpacError>) {
+            description("Multiple errors")
+            display("Multiple errors:\n{}", MultipleErrorFormatter(errors))
+        }
+    }
+}
+
+use std::fmt::{Display, Formatter, Result};
+
+struct ParseErrorFormatter<'fmt>(&'fmt Vec<ParseError<(), lexer::Token, ()>>);
+
+impl<'fmt> Display for ParseErrorFormatter<'fmt> {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        for (i, error) in self.0.iter().enumerate() {
+            write!(f, "{}: ", i)?;
+            match *error {
+                ParseError::InvalidToken { .. } => {
+                    write!(f, "Invalid token")?
+                }
+                ParseError::UnrecognizedToken {
+                    ref token,
+                    ref expected,
+                } => {
+                    match *token {
+                        Some(ref x) => writeln!(f, "Unexpected {:?}", x.1),
+                        _ => writeln!(f, "Unexpected end of file"),
+                    }?;
+                    write!(f, "   Expected one of:\n   {}", expected.join(", "))?
+                }
+                ParseError::ExtraToken { ref token } => {
+                    write!(f, "Extra token detected: {:?}", token)?
+                }
+                ParseError::User { ref error } => {
+                    write!(f, "{:?}", error)?
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+struct MultipleErrorFormatter<'fmt>(&'fmt Vec<DacpacError>);
+
+impl<'fmt> Display for MultipleErrorFormatter<'fmt> {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        for (i, error) in self.0.iter().enumerate() {
+            write!(f, "--- Error {} ---\n{}", i, error.display())?;
+        }
+        Ok(())
     }
 }

--- a/dacpac/src/lib.rs
+++ b/dacpac/src/lib.rs
@@ -23,4 +23,3 @@ mod sql;
 
 pub use errors::*;
 pub use dacpac::Dacpac;
-pub use lalrpop_util::ParseError;


### PR DESCRIPTION
`error-chain` errors implement `Display` and `Debug` and includes some really easy ways to generate formatted descriptions of errors (including errors back up the chain). 

I've moved the error display logic into the error definitions so we can take advantages of this, simplifying some of the code as I went. Defining the custom formats is a bit verbose, requiring a newtype etc, there is probably a better place to put it, which I'm thinking about.