### PR TITLE
Beginning of column modification logic/tests

### DIFF
--- a/psqlpack/src/model/package.rs
+++ b/psqlpack/src/model/package.rs
@@ -1108,7 +1108,7 @@ mod tests {
 
         // Add the column and try again
         {
-            let mut parent = package
+            let parent = package
                 .tables
                 .iter_mut()
                 .find(|t| t.name.name.eq("parent"))
@@ -1155,7 +1155,7 @@ mod tests {
 
         // Add the column and try again
         {
-            let mut child = package
+            let child = package
                 .tables
                 .iter_mut()
                 .find(|t| t.name.name.eq("child"))

--- a/psqlpack/src/model/profiles.rs
+++ b/psqlpack/src/model/profiles.rs
@@ -24,6 +24,7 @@ pub struct GenerationOptions {
 }
 
 impl PublishProfile {
+    #[allow(dead_code)]
     pub fn new() -> Self {
         PublishProfile {
             version: "1.0".to_owned(),

--- a/psqlpack/src/model/project.rs
+++ b/psqlpack/src/model/project.rs
@@ -36,6 +36,7 @@ pub struct Project {
 }
 
 impl Project {
+    #[allow(dead_code)]
     pub(crate) fn default() -> Self {
         Project {
             path: None,

--- a/psqlpack/src/sql/ast.rs
+++ b/psqlpack/src/sql/ast.rs
@@ -9,14 +9,14 @@ pub enum Statement {
     Type(TypeDefinition),
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub enum SqlType {
     Simple(SimpleSqlType),
     Array(SimpleSqlType, u32),
     Custom(String, Option<String>),
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub enum SimpleSqlType {
     FixedLengthString(u32),    // char(size)
     VariableLengthString(u32), // varchar(size)
@@ -50,7 +50,7 @@ pub enum SimpleSqlType {
     Uuid, // uuid
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub enum ColumnConstraint {
     Default(AnyValue),
     NotNull,
@@ -59,7 +59,7 @@ pub enum ColumnConstraint {
     PrimaryKey,
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub enum AnyValue {
     Boolean(bool),
     Integer(i32),
@@ -131,7 +131,7 @@ pub struct TableDefinition {
     pub constraints: Option<Vec<TableConstraint>>,
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub struct ColumnDefinition {
     pub name: String,
     pub sql_type: SqlType,

--- a/psqlpack/src/sql/ast.rs
+++ b/psqlpack/src/sql/ast.rs
@@ -9,14 +9,14 @@ pub enum Statement {
     Type(TypeDefinition),
 }
 
-#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub enum SqlType {
     Simple(SimpleSqlType),
     Array(SimpleSqlType, u32),
     Custom(String, Option<String>),
 }
 
-#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub enum SimpleSqlType {
     FixedLengthString(u32),    // char(size)
     VariableLengthString(u32), // varchar(size)
@@ -50,7 +50,7 @@ pub enum SimpleSqlType {
     Uuid, // uuid
 }
 
-#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub enum ColumnConstraint {
     Default(AnyValue),
     NotNull,
@@ -59,7 +59,7 @@ pub enum ColumnConstraint {
     PrimaryKey,
 }
 
-#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub enum AnyValue {
     Boolean(bool),
     Integer(i32),
@@ -131,7 +131,7 @@ pub struct TableDefinition {
     pub constraints: Option<Vec<TableConstraint>>,
 }
 
-#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub struct ColumnDefinition {
     pub name: String,
     pub sql_type: SqlType,


### PR DESCRIPTION
This is the start of the column modification logic. 

I suspect we'll want to add further validation rules about what can and cannot be changed somewhere. Validation rules returned from `generate` could be an interesting extension. I'm thinking it could return a vector of "Violations" which the publish profile could then "filter" before potentially erroring out if more exist. This is more for things like changing a `binary` type to an `int` or something stupid.

This PR ignores changing table constraints at a column level at the moment, e.g. adding `UNIQUE` or removing `UNIQUE` at a column level. These are anonymous table level constraints so we'll need to likely extend the AST to support these types as well as loop through them as part of #30. 

One other change in this PR is the merging of `delta.rs` and `profiles.rs` into a single `publish.rs`. I've been struggling remembering what each file is responsible for; this is perhaps a step towards association each file with the operation it's closely tied to.

Anyway, keen to hear your thoughts on 