### PR TITLE
Introduction of basic integration testing infrastructure for ensuring correct generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,13 +1,3 @@
-[root]
-name = "psqlpack-cli"
-version = "0.1.0"
-dependencies = [
- "clap 2.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "psqlpack 0.1.0",
- "slog 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-term 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "aho-corasick"
 version = "0.6.3"
@@ -659,6 +649,16 @@ dependencies = [
  "spectral 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "psqlpack-cli"
+version = "0.1.0"
+dependencies = [
+ "clap 2.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "psqlpack 0.1.0",
+ "slog 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-term 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
+.DEFAULT_GOAL := build
 
 OSFLAG 				:=
 ifeq ($(OS),Windows_NT)
@@ -20,8 +21,8 @@ else
 	RM_BK += find . -name *.bk -delete
 endif
 
-clean:
-	$(RM_BK) 
-
 build:
 	cargo build -p psqlpack-cli
+
+clean:
+	$(RM_BK)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,6 +5,8 @@ extern crate psqlpack;
 extern crate slog;
 extern crate slog_term;
 
+mod operation;
+
 use std::env;
 use std::path::Path;
 use std::time::Instant;
@@ -14,7 +16,7 @@ use std::result;
 
 use clap::{App, Arg, ArgMatches, SubCommand};
 use slog::{Drain, Logger};
-use psqlpack::{operation, ChainedError, PsqlpackResult};
+use psqlpack::{ChainedError, PsqlpackResult};
 
 /// A threadsafe toggle.
 #[derive(Clone)]

--- a/cli/src/operation.rs
+++ b/cli/src/operation.rs
@@ -2,9 +2,7 @@ use std::path::Path;
 
 use slog::Logger;
 
-use model::{Delta, Package, Project, PublishProfile};
-use errors::PsqlpackResult;
-use errors::PsqlpackErrorKind::PackageCreationError;
+use psqlpack::{Delta, Package, Project, PsqlpackResult, PsqlpackErrorKind, PublishProfile};
 
 pub fn package<L: Into<Logger>>(log: L, project_path: &Path, output_path: &Path) -> PsqlpackResult<()> {
     let log = log.into().new(o!("operation" => "package"));
@@ -25,7 +23,7 @@ pub fn extract<L: Into<Logger>>(log: L, source_connection_string: &str, target_p
             trace!(log, "Writing Package"; "output" => target_package_path.to_str().unwrap());
             data.write_to(target_package_path)
         }
-        None => bail!(PackageCreationError("database does not exist".into())),
+        None => Err(PsqlpackErrorKind::PackageCreationError("database does not exist".into()).into()),
     }
 }
 

--- a/psqlpack/src/errors.rs
+++ b/psqlpack/src/errors.rs
@@ -66,6 +66,9 @@ error_chain! {
         PackageQueryTablesError {
             description("Couldn't query tables")
         }
+        PackageQueryColumnsError {
+            description("Couldn't query columns")
+        }
         PackageFunctionArgsInspectError(args: String) {
             description("Couldn't inspect function args")
             display("Couldn't inspect function args: {}", args)

--- a/psqlpack/src/lib.rs
+++ b/psqlpack/src/lib.rs
@@ -25,7 +25,10 @@ pub use errors::*;
 mod connection;
 mod sql;
 mod model;
-pub mod operation;
+
+pub use model::{Delta, Package, Project, PublishProfile};
+pub use errors::PsqlpackResult;
+pub use errors::PsqlpackErrorKind;
 
 /// Allows usage of no logging, std `log`, or slog.
 pub enum LogConfig {

--- a/psqlpack/src/lib.rs
+++ b/psqlpack/src/lib.rs
@@ -26,6 +26,9 @@ mod connection;
 mod sql;
 mod model;
 
+pub mod ast {
+    pub use sql::ast::*;  
+}
 pub use connection::ConnectionBuilder;
 pub use errors::{PsqlpackErrorKind, PsqlpackResult};
 pub use model::{Delta, Package, Project, PublishProfile};

--- a/psqlpack/src/lib.rs
+++ b/psqlpack/src/lib.rs
@@ -26,9 +26,9 @@ mod connection;
 mod sql;
 mod model;
 
+pub use connection::ConnectionBuilder;
+pub use errors::{PsqlpackErrorKind, PsqlpackResult};
 pub use model::{Delta, Package, Project, PublishProfile};
-pub use errors::PsqlpackResult;
-pub use errors::PsqlpackErrorKind;
 
 /// Allows usage of no logging, std `log`, or slog.
 pub enum LogConfig {

--- a/psqlpack/src/model/package.rs
+++ b/psqlpack/src/model/package.rs
@@ -54,7 +54,7 @@ impl<'row> From<Row<'row>> for ExtensionDefinition {
 }
 
 static Q_SCHEMAS: &'static str = "SELECT schema_name FROM information_schema.schemata
-                                  WHERE catalog_name = $1 AND schema_owner <> 'postgres'";
+                                  WHERE catalog_name = $1 AND schema_name !~* 'pg_|information_schema'";
 impl<'row> From<Row<'row>> for SchemaDefinition {
     fn from(row: Row) -> Self {
         SchemaDefinition { name: row.get(0) }

--- a/psqlpack/src/model/package.rs
+++ b/psqlpack/src/model/package.rs
@@ -140,6 +140,7 @@ macro_rules! map {
                                    FROM pg_attribute
                                    WHERE attnum > 0 AND attrelid IN ({})";*/
 
+#[derive(Debug, PartialEq)]
 pub struct Package {
     pub extensions: Vec<ExtensionDefinition>,
     pub functions: Vec<FunctionDefinition>,
@@ -215,6 +216,7 @@ impl Package {
         if db_result.is_empty() {
             return Ok(None);
         }
+        dbtry!(db_conn.finish());
 
         // We do five SQL queries to get the package details
         let db_conn = connection.connect_database()?;
@@ -296,6 +298,7 @@ impl Package {
         let tables = db_conn
             .query(Q_TABLES, &[])
             .chain_err(|| PackageQueryTablesError)?;
+        dbtry!(db_conn.finish());
 
         Ok(Some(Package {
             extensions: map!(extensions),

--- a/psqlpack/src/model/package.rs
+++ b/psqlpack/src/model/package.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::path::Path;
 use std::fs::File;
@@ -39,6 +40,12 @@ macro_rules! zip_collection {
             };
             ztry!($zip.write_all(json.as_bytes()));
         }
+    }};
+}
+
+macro_rules! map {
+    ($expr:expr) => {{
+        $expr.iter().map(|row| row.into()).collect()
     }};
 }
 
@@ -99,7 +106,7 @@ static Q_FUNCTIONS: &'static str = "SELECT
                                     LEFT JOIN pg_depend ON
                                         pg_depend.objid = pg_proc.oid AND pg_depend.deptype = 'e'
                                     WHERE pg_depend.objid IS NULL AND
-                                          nspname NOT IN ('pg_catalog', 'information_schema');";
+                                          nspname !~* 'pg_|information_schema';";
 
 static Q_TABLES: &'static str = "SELECT
                                     pg_class.oid,
@@ -116,7 +123,7 @@ static Q_TABLES: &'static str = "SELECT
                                     pg_constraint.conrelid = pg_class.oid
                                 WHERE pg_class.relkind='r' AND
                                       pg_depend.objid IS NULL AND
-                                      nspname NOT IN ('pg_catalog', 'information_schema')";
+                                      nspname !~* 'pg_|information_schema'";
 impl<'row> From<Row<'row>> for TableDefinition {
     fn from(row: Row) -> Self {
         TableDefinition {
@@ -130,15 +137,61 @@ impl<'row> From<Row<'row>> for TableDefinition {
     }
 }
 
-macro_rules! map {
-    ($expr:expr) => {{
-        $expr.iter().map(|row| row.into()).collect()
-    }};
+static Q_COLUMNS : &'static str =  "SELECT DISTINCT
+                                        ns.nspname as schema_name,
+                                        pgc.relname as table_name,
+                                        a.attnum as num,
+                                        a.attname as name,
+                                        CASE WHEN a.atttypid = ANY ('{int,int8,int2}'::regtype[])
+                                              AND def.adsrc = 'nextval('''
+                                                    || (pg_get_serial_sequence (a.attrelid::regclass::text, a.attname))::regclass
+                                                    || '''::regclass)'
+                                            THEN CASE a.atttypid
+                                                    WHEN 'int'::regtype  THEN 'serial'
+                                                    WHEN 'int8'::regtype THEN 'bigserial'
+                                                    WHEN 'int2'::regtype THEN 'smallserial'
+                                                 END
+                                            ELSE format_type(a.atttypid, a.atttypmod)
+                                        END AS data_type,
+                                        a.attnotnull as notnull,
+                                        coalesce(i.indisprimary,false) as primary_key,
+                                        def.adsrc as default
+                                    FROM pg_attribute a
+                                    INNER JOIN pg_class pgc ON pgc.oid = a.attrelid
+                                    INNER JOIN pg_namespace ns ON ns.oid = pgc.relnamespace
+                                    LEFT JOIN pg_index i ON pgc.oid = i.indrelid AND i.indkey[0] = a.attnum
+                                    LEFT JOIN pg_attrdef def ON a.attrelid = def.adrelid AND a.attnum = def.adnum
+                                    WHERE attnum > 0 AND pgc.relkind='r' AND NOT a.attisdropped AND ns.nspname !~* 'pg_|information_schema'
+                                    ORDER BY pgc.relname, a.attnum";
+
+impl<'row> From<Row<'row>> for ColumnDefinition {
+    fn from(row: Row) -> Self {
+        // Do the column constraints first
+        let mut constraints = Vec::new();
+        let not_null : bool = row.get(5);
+        let primary_key : bool = row.get(6);
+        // TODO: Default value + unique
+        constraints.push(if not_null { ColumnConstraint::NotNull } else { ColumnConstraint::Null });
+        if primary_key {
+            constraints.push(ColumnConstraint::PrimaryKey);
+        }
+        let sql_type : String = row.get(4);
+
+        ColumnDefinition {
+            name: row.get(3),
+            sql_type: sql_type.into(),
+            constraints: Some(constraints),
+        }
+    }
 }
 
-/*static Q_COLUMNS : &'static str = "SELECT attrelid, attname, format_type(atttypid, atttypmod), attnotnull
-                                   FROM pg_attribute
-                                   WHERE attnum > 0 AND attrelid IN ({})";*/
+impl From<String> for SqlType {
+    fn from(s: String) -> Self {
+        // TODO: Error handling for this
+        let tokens = lexer::tokenize(&s).unwrap();
+        parser::parse_sql_type(tokens).unwrap()
+    }
+}
 
 #[derive(Debug, PartialEq)]
 pub struct Package {
@@ -295,9 +348,28 @@ impl Package {
             });
         }
 
-        let tables = db_conn
-            .query(Q_TABLES, &[])
-            .chain_err(|| PackageQueryTablesError)?;
+        let mut tables = HashMap::new();
+        for row in &db_conn.query(Q_TABLES, &[])
+                           .chain_err(|| PackageQueryTablesError)? {
+            let table : TableDefinition = row.into();
+            tables.insert(table.name.to_string(), table);
+        }
+
+        // Get a list of columns and map them to the appropriate tables
+        for row in &db_conn.query(Q_COLUMNS, &[])
+                           .chain_err(|| PackageQueryColumnsError)? {
+            // Get the table name and find it in our collection
+            let schema : String = row.get(0);
+            let table : String = row.get(1);
+            let key = format!("{}.{}", schema, table);
+
+            // Now look up the mutable key
+            if let Some(definition) = tables.get_mut(&key) {
+                definition.columns.push(row.into());
+            }
+        }
+
+        // Close the connection
         dbtry!(db_conn.finish());
 
         Ok(Some(Package {
@@ -305,7 +377,7 @@ impl Package {
             functions: functions,   // functions,
             schemas: map!(schemas), // schemas,
             scripts: Vec::new(),    // Scripts can't be known from a connection
-            tables: map!(tables),   // tables,
+            tables: tables.into_iter().map(|(_,b)| b).collect(),   // tables,
             types: map!(types),     // types,
         }))
     }

--- a/psqlpack/src/model/project.rs
+++ b/psqlpack/src/model/project.rs
@@ -37,7 +37,7 @@ pub struct Project {
 
 impl Project {
     #[allow(dead_code)]
-    pub(crate) fn default() -> Self {
+    pub fn default() -> Self {
         Project {
             path: None,
             version: "1.0".into(),

--- a/psqlpack/src/sql/ast.rs
+++ b/psqlpack/src/sql/ast.rs
@@ -138,28 +138,28 @@ pub struct ColumnDefinition {
     pub constraints: Option<Vec<ColumnConstraint>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct SchemaDefinition {
     pub name: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ExtensionDefinition {
     pub name: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct TypeDefinition {
     pub name: String,
     pub kind: TypeDefinitionKind,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum TypeDefinitionKind {
     Enum(Vec<String>),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ScriptDefinition {
     pub name: String,
     pub kind: ScriptKind,
@@ -167,7 +167,7 @@ pub struct ScriptDefinition {
     pub contents: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ScriptKind {
     PreDeployment,
     PostDeployment,

--- a/psqlpack/src/sql/parser.lalrpop
+++ b/psqlpack/src/sql/parser.lalrpop
@@ -273,7 +273,7 @@ foreign_constraint_action: ForeignConstraintAction = {
     SET DEFAULT => ForeignConstraintAction::SetDefault,
 };
 
-sql_type: SqlType = {
+pub sql_type: SqlType = {
     <simple_type> => SqlType::Simple(<>),
     <simple:simple_type> <dim:array_dimension> => SqlType::Array(simple, dim),
     <Ident> => SqlType::Custom(<>, None),

--- a/psqlpack/tests/common/mod.rs
+++ b/psqlpack/tests/common/mod.rs
@@ -1,17 +1,88 @@
 macro_rules! drop_db {
     ($connection:expr) => {{
-
+        let connection = $connection.connect_host().unwrap();
+        connection.query("SELECT pg_terminate_backend(pg_stat_activity.pid) \
+                          FROM pg_stat_activity \
+                          WHERE pg_stat_activity.datname = $1;", &[&$connection.database()]).unwrap();
+        connection.query(&format!("DROP DATABASE IF EXISTS {}", $connection.database()), &[]).unwrap();
+        connection.finish().unwrap();
     }};
 }
 
 macro_rules! generate_simple_package {
-    ($namespace:expr) => {{
-        Package::new()
+    ($namespace:ident) => {{
+        {
+            let mut package = Package::new();
+            package.push_schema(SchemaDefinition {
+                name: $namespace.to_string(),
+            });
+            package.push_table(TableDefinition {
+                name: ObjectName {
+                    schema: Some($namespace.to_string()),
+                    name: "contacts".into()
+                },
+                columns: vec![
+                    ColumnDefinition {
+                        name: "id".into(),
+                        sql_type: SqlType::Simple(SimpleSqlType::Serial),
+                        constraints: Some(vec![
+                            ColumnConstraint::PrimaryKey, 
+                            ColumnConstraint::NotNull
+                        ])
+                    },
+                    ColumnDefinition {
+                        name: "name".into(),
+                        sql_type: SqlType::Simple(SimpleSqlType::VariableLengthString(50)),
+                        constraints: Some(vec![ColumnConstraint::NotNull])
+                    },
+                ],
+                constraints: None,
+            });
+            package.validate().unwrap();
+            package
+        }
     }};
 }
 
 macro_rules! assert_simple_package {
-    ($db_name:expr, $namespace:expr, $connection:expr) => {{
+    ($package:ident, $namespace:ident) => {{
+        // Assert that the package exists in the expected format
+        assert_that!($package.schemas).has_length(1);
+        let schema = &$package.schemas[0];
+        assert_that!(schema.name).is_equal_to($namespace.to_string());
 
+        // Validate the table
+        assert_that!($package.tables).has_length(1);
+        let table = &$package.tables[0];
+        assert_that!(table.name.to_string()).is_equal_to(format!("{}.contacts", $namespace));
+        assert_that!(table.columns).has_length(2);
+        assert_that!(table.constraints).is_none();
+
+        // Validate the id column
+        let col_id = &table.columns[0];
+        assert_that!(col_id.name).is_equal_to("id".to_string());
+        assert_that!(col_id.sql_type).is_equal_to(SqlType::Simple(SimpleSqlType::Serial));
+        assert_that!(col_id.constraints).is_some().has_length(2);
+        match col_id.constraints {
+            Some(ref constraints) => {
+                let constraints = constraints.iter();
+                assert_that!(constraints).contains(ColumnConstraint::PrimaryKey);
+                assert_that!(constraints).contains(ColumnConstraint::NotNull);
+            }
+            None => panic!("Expected constraints to exist for contacts.id"),
+        }
+
+        // Validate the name column
+        let col_name = &table.columns[1];
+        assert_that!(col_name.name).is_equal_to("name".to_string());
+        assert_that!(col_name.sql_type).is_equal_to(SqlType::Simple(SimpleSqlType::VariableLengthString(50)));
+        assert_that!(col_name.constraints).is_some().has_length(1);
+        match col_name.constraints {
+            Some(ref constraints) => {
+                let constraints = constraints.iter();
+                assert_that!(constraints).contains(ColumnConstraint::NotNull);
+            }
+            None => panic!("Expected constraints to exist for contacts.name"),
+        }       
     }};
 }

--- a/psqlpack/tests/common/mod.rs
+++ b/psqlpack/tests/common/mod.rs
@@ -1,0 +1,17 @@
+macro_rules! drop_db {
+    ($connection:expr) => {{
+
+    }};
+}
+
+macro_rules! generate_simple_package {
+    ($namespace:expr) => {{
+        Package::new()
+    }};
+}
+
+macro_rules! assert_simple_package {
+    ($db_name:expr, $namespace:expr, $connection:expr) => {{
+
+    }};
+}

--- a/psqlpack/tests/common/mod.rs
+++ b/psqlpack/tests/common/mod.rs
@@ -38,6 +38,7 @@ macro_rules! generate_simple_package {
                 ],
                 constraints: None,
             });
+            package.set_defaults(&Project::default());
             package.validate().unwrap();
             package
         }
@@ -47,9 +48,9 @@ macro_rules! generate_simple_package {
 macro_rules! assert_simple_package {
     ($package:ident, $namespace:ident) => {{
         // Assert that the package exists in the expected format
-        assert_that!($package.schemas).has_length(1);
-        let schema = &$package.schemas[0];
-        assert_that!(schema.name).is_equal_to($namespace.to_string());
+        assert_that!($package.schemas).has_length(2);
+        assert!(&$package.schemas.iter().any(|s| s.name.eq($namespace)));
+        assert!(&$package.schemas.iter().any(|s| s.name.eq("public")));
 
         // Validate the table
         assert_that!($package.tables).has_length(1);

--- a/psqlpack/tests/publish.rs
+++ b/psqlpack/tests/publish.rs
@@ -1,0 +1,42 @@
+extern crate psqlpack;
+#[macro_use]
+extern crate slog;
+
+#[macro_use]
+mod common;
+
+use psqlpack::*;
+use slog::{Discard, Drain, Logger};
+
+#[test]
+fn it_can_create_a_database_that_doesnt_exist() {
+    const DB_NAME : &str = "psqlpack_new_db";
+    const NAMESPACE : &str = "it_can_create_a_database_that_doesnt_exist";
+
+    // Preliminary: remove existing database
+    let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
+    drop_db!(connection);
+
+    // Create a package
+    let package = generate_simple_package!(NAMESPACE);
+
+    // Use the default publish profile
+    let publish_profile = PublishProfile::new();
+
+    // Create a target package from connection string
+    let log = Logger::root(Discard.fuse(), o!());
+    let target_package = Package::from_connection(&log, &connection).unwrap();
+
+    // Generate delta and apply
+    let delta = Delta::generate(
+        &log,
+        &package,
+        target_package,
+        DB_NAME.into(),
+        publish_profile,
+    ).unwrap();
+    delta.apply(&log, &connection).ok();
+
+    // Confirm db exists with data
+    assert_simple_package!(DB_NAME, NAMESPACE, connection);
+}

--- a/psqlpack/tests/publish.rs
+++ b/psqlpack/tests/publish.rs
@@ -1,12 +1,16 @@
 extern crate psqlpack;
 #[macro_use]
 extern crate slog;
+#[macro_use]
+extern crate spectral;
 
 #[macro_use]
 mod common;
 
 use psqlpack::*;
+use psqlpack::ast::*;
 use slog::{Discard, Drain, Logger};
+use spectral::prelude::*;
 
 #[test]
 fn it_can_create_a_database_that_doesnt_exist() {
@@ -35,8 +39,10 @@ fn it_can_create_a_database_that_doesnt_exist() {
         DB_NAME.into(),
         publish_profile,
     ).unwrap();
-    delta.apply(&log, &connection).ok();
+    delta.apply(&log, &connection).unwrap();
 
     // Confirm db exists with data
-    assert_simple_package!(DB_NAME, NAMESPACE, connection);
+    let final_package = Package::from_connection(&log, &connection).unwrap().unwrap();
+    assert_that!(final_package).is_equal_to(&package);
+    assert_simple_package!(final_package, NAMESPACE);
 }

--- a/psqlpack/tests/publish.rs
+++ b/psqlpack/tests/publish.rs
@@ -43,6 +43,7 @@ fn it_can_create_a_database_that_doesnt_exist() {
 
     // Confirm db exists with data
     let final_package = Package::from_connection(&log, &connection).unwrap().unwrap();
-    assert_that!(final_package).is_equal_to(&package);
+    // TODO: Would be nice to be able to do this, however we'd need to implement PartialEq manually
+    //assert_that!(final_package).is_equal_to(&package);
     assert_simple_package!(final_package, NAMESPACE);
 }

--- a/psqlpack/tests/publish_sql.rs
+++ b/psqlpack/tests/publish_sql.rs
@@ -1,0 +1,4 @@
+#[test]
+fn it_can_create_a_database_that_doesnt_exist() {
+    
+}

--- a/psqlpack/tests/publish_sql.rs
+++ b/psqlpack/tests/publish_sql.rs
@@ -1,4 +1,0 @@
-#[test]
-fn it_can_create_a_database_that_doesnt_exist() {
-    
-}


### PR DESCRIPTION
# Overview

This PR introduces the concept of an integration testing framework which also includes some minor refactoring to allow for future testing without the reliance of a file system. All in all, the introduced test is relatively useless (i.e. creates a database that doesn't exist with a single table) however does start to cover some of the integration testing points and consequently fixes a couple of bugs.

This is in reference to issue #84.

# Details

## Refactored `operation.rs` out of `psqlpack` and into the CLI. 

The original reason for `operation.rs` in `psqlpack` was to avoid leaking internal implementation out of the library and instead enforce an opinionated approach to the use of this library. The downside of this was that `psqlpack` was responsible for all possible uses of this library. Since `operation.rs` was very tied to the file system (i.e. instead of streams etc) the easiest way forward was to move this into the CLI and retain the operation syntax that we'd already been leveraging. This worked out pretty well as the changes were quite minor - i.e. exposing some internal types and leveraging them from the CLI.

The only "weird" thing from all of this is the error handling change for `extract`. Rather than pull in `error-chain` just for this one use, I instead just "reimplement" the equivalent `bail` macro. I didn't particularly want to bring `error-chain` over in case we want to migrate to `failure` in the future.

## Exposed internal AST

For integration tests to build a package representation without a DSL I needed to also expose the AST objects. To ensure that these continue to be namespaced, they're exposed under the logical mod `ast`. This will prevent the documentation becoming convoluted as well as logically separating the common scenario's (i.e. enabling the opinionated use of the library).

## Updated to be able to generate columns correctly on apply

One major thing I change is that for new databases we use the same generation path as existing databases within `delta.rs`. This is an important change as it means that it is easier to diagnose issues and ensure similar generation paths. The downside is that it is _slightly_ unoptimal since we _know_ the database objects don't exist. I think this can be a future optimization (if need be) once we have reached 1.0.

The other change in `delta` was to terminate connections before database dropping. Because the tests run as `postgres` I found there was often connection collusion - this helps prevent this and allows us to drop the database easily. This _could_ be specified by a publish profile in the future if it's deemed a problem however dropping the database is pretty extreme already so I'm not sure the added check is necessary.

## Update package to be able to load columns from a connection

Previously, this was a big "TODO" in the project. After this PR, it still has a "TODO" about it however it is a lot closer to being usable - columns are now loaded.

Tables are now generated mutably with the columns added afterwards - which ultimately is how the AST is structured. The column SQL is quite complex however in a nutshell:
* Columns are stored in `pg_attribute`
* I join onto the tables, and then the schemas
* I optionally also join onto the index table (for primary keys) and the defaults table (for... defaults).
* From this I can filter out system tables as well as infer various bits of information
* The `serial` type is an "alias" of sorts so there is some extra logic to handle that in the `CASE` statement

This ultimately required exposing the parser function `parse_sql_type` so we ultimately reuse existing `lalrpop` logic for parsing types.

## Other changes
* Update schema exclusion to use a `pg_` wildcard (that is a reserved format)
* Fixes the default build step for the `Makefile`.
* Project `default()` is now exposed publicly. In the future, we should probably use the `Default` trait.
* Package implements `PartialEq` - initially I wanted to be able to assert equality at a package level in addition to checking the contents however I wanted to ignore order which would require a custom implementation. Kept for future use.