### PR TITLE
Abstracted Column Definitions into logical Diffable structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,12 +224,13 @@ dependencies = [
 
 [[package]]
 name = "docopt"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -338,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.5.10"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -360,57 +361,58 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.13.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ena 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-intern 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-snap 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-util 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-snap 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "lalrpop-intern"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "lalrpop-snap"
-version = "0.13.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ena 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-intern 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-util 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lalrpop-util"
 version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lalrpop-util"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -498,6 +500,14 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -589,6 +599,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.7.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "phf_shared"
 version = "0.7.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,11 +663,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "psqlpack"
 version = "0.1.0"
 dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -678,6 +710,14 @@ dependencies = [
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"
@@ -861,6 +901,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "new_debug_unreachable 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_generator 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "string_cache_shared"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +1054,11 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unreachable"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,7 +1163,7 @@ dependencies = [
 "checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "00a49051fef47a72c9623101b19bd71924a45cca838826caae3eaa4d00772603"
-"checksum docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab32ea6e284d87987066f21a9e809a73c14720571ef34516f0890b3d355ccfd8"
+"checksum docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8acd393692c503b168471874953a2531df0e9ab77d0b6bbc582395743300a4a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum ena 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe5a5078ac8c506d3e4430763b1ba9b609b1286913e7d08e581d1c2de9b7e5"
@@ -1103,13 +1179,13 @@ dependencies = [
 "checksum hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum isatty 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f2a233726c7bb76995cec749d59582e5664823b7245d4970354408f1d79a7a2"
-"checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
+"checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lalrpop 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8ebe5a5c90d5edeecb7f62f6ebec0a3d0f6faf4759a052708348cda99fd311a0"
-"checksum lalrpop-intern 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05410c1e4aff497bdea1ccb274ac35536fda0ee858600df36966502d4f7acbe3"
-"checksum lalrpop-snap 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f866ece35287f5223a1a022c5d86417c260cda2ca9c8a156af9959404ce5313"
+"checksum lalrpop 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ba451f7bd819b7afc99d4cf4bdcd5a4861e64955ba9680ac70df3a50625ad6cf"
+"checksum lalrpop-snap 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "60013fd6be14317d43f47658b1440956a9ca48a9ed0257e0e0a59aac13e43a1f"
 "checksum lalrpop-util 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7c7743f235fc17f5f50f3b1e64a8690ee154f17f86bd68cbb78787c5b37907f7"
+"checksum lalrpop-util 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "60c6c48ba857cd700673ce88907cadcdd7e2cd7783ed02378537c5ffd4f6460c"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)" = "56aebce561378d99a0bb578f8cb15b6114d2a1814a6c7949bbe646d968bb4fa9"
@@ -1122,6 +1198,7 @@ dependencies = [
 "checksum miniz_oxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aaa2d3ad070f428fffbd7d3ca2ea20bb0d8cffe9024405c44e1840bc1418b398"
 "checksum miniz_oxide_c_api 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "92d98fdbd6145645828069b37ea92ca3de225e000d80702da25c20d3584b38a5"
 "checksum msdos_time 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "65ba9d75bcea84e07812618fedf284a64776c2f2ea0cad6bca7f69739695a958"
+"checksum new_debug_unreachable 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0cdc457076c78ab54d5e0d6fa7c47981757f1e34dc39ff92787f217dede586c4"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "81b483ea42927c463e191802e7334556b48e7875297564c0e9951bd3a0ae53e3"
 "checksum num-complex 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "26ff8edeab9f1d8cf6b595e35138c2a389ea29f4f57a0e6bc44abf406e4b0077"
@@ -1132,12 +1209,16 @@ dependencies = [
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 "checksum petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7e5234c228fbfa874c86a77f685886127f82e0aef602ad1d48333fcac6ad61"
 "checksum phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "cb325642290f28ee14d8c6201159949a872f220c62af6e110a56ea914fbe42fc"
+"checksum phf_generator 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6b07ffcc532ccc85e3afc45865469bf5d9e4ef5bfcf9622e3cfe80c2d275ec03"
 "checksum phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "07e24b0ca9643bdecd0632f2b3da6b1b89bbb0030e0b992afc1113b23a7bc2f2"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 "checksum postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "115dde90ef51af573580c035857badbece2aa5cde3de1dfb3c932969ca92a6c5"
 "checksum postgres-protocol 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2487e66455bf88a1b247bf08a3ce7fe5197ac6d67228d920b0ee6a0e97fd7312"
 "checksum postgres-shared 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bafecadf25b7de9a5f747e93073db444c9ddcc7b3ae37bcdf63c2508f9a17f2d"
+"checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
@@ -1160,6 +1241,9 @@ dependencies = [
 "checksum slog-term 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5bb5d9360b2b279b326824b3b4ca2402ead8a8138f0e5ec1900605c861bb6671"
 "checksum socket2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "630d23c56fe67dc851155459ed2ad37c5112e3877855b666970e08e5ad08a7fb"
 "checksum spectral 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
+"checksum string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25d70109977172b127fe834e5449e5ab1740b9ba49fa18a2020f509174f25423"
+"checksum string_cache_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "35293b05cf1494e8ddd042a7df6756bf18d07f42d234f32e71dce8a7aabb0191"
+"checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
 "checksum stringprep 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
@@ -1176,6 +1260,7 @@ dependencies = [
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"

--- a/psqlpack/Cargo.toml
+++ b/psqlpack/Cargo.toml
@@ -22,7 +22,7 @@ zip = "0.2"
 petgraph = "0.4"
 
 [build-dependencies]
-lalrpop = "0.13"
+lalrpop = "0.15"
 
 [dev-dependencies]
 spectral = "0.6.0"

--- a/psqlpack/src/connection.rs
+++ b/psqlpack/src/connection.rs
@@ -1,4 +1,3 @@
-use std::ascii::AsciiExt;
 use std::str::FromStr;
 
 use postgres::{Connection as PostgresConnection, TlsMode};

--- a/psqlpack/src/errors.rs
+++ b/psqlpack/src/errors.rs
@@ -100,11 +100,11 @@ error_chain! {
                 "SQL syntax error encountered in {} on line {}:\n  {}\n  {}{}",
                 file, line_number, line, " ".repeat(*start), "^".repeat(end - start))
         }
-        ParseError(file: String, errors: Vec<ParseError<(), lexer::Token, ()>>) {
+        ParseError(file: String, errors: Vec<ParseError<(), lexer::Token, &'static str>>) {
             description("Parser error")
             display("Parser errors in {}:\n{}", file, ParseErrorsFormatter(errors))
         }
-        InlineParseError(error: ParseError<(), lexer::Token, ()>) {
+        InlineParseError(error: ParseError<(), lexer::Token, &'static str>) {
             description("Parser error")
             display("Parser error: {}", ParseErrorFormatter(error))
         }
@@ -149,7 +149,7 @@ error_chain! {
 
 use std::fmt::{Display, Formatter, Result};
 
-fn write_err(f: &mut Formatter, error: &ParseError<(), lexer::Token, ()>) -> Result {
+fn write_err(f: &mut Formatter, error: &ParseError<(), lexer::Token, &'static str>) -> Result {
     match *error {
         ParseError::InvalidToken { .. } => write!(f, "Invalid token"),
         ParseError::UnrecognizedToken {
@@ -167,7 +167,7 @@ fn write_err(f: &mut Formatter, error: &ParseError<(), lexer::Token, ()>) -> Res
     }
 }
 
-struct ParseErrorsFormatter<'fmt>(&'fmt Vec<ParseError<(), lexer::Token, ()>>);
+struct ParseErrorsFormatter<'fmt>(&'fmt Vec<ParseError<(), lexer::Token, &'static str>>);
 
 impl<'fmt> Display for ParseErrorsFormatter<'fmt> {
     fn fmt(&self, f: &mut Formatter) -> Result {
@@ -179,7 +179,7 @@ impl<'fmt> Display for ParseErrorsFormatter<'fmt> {
     }
 }
 
-struct ParseErrorFormatter<'fmt>(&'fmt ParseError<(), lexer::Token, ()>);
+struct ParseErrorFormatter<'fmt>(&'fmt ParseError<(), lexer::Token, &'static str>);
 
 impl<'fmt> Display for ParseErrorFormatter<'fmt> {
     fn fmt(&self, f: &mut Formatter) -> Result {

--- a/psqlpack/src/model/delta.rs
+++ b/psqlpack/src/model/delta.rs
@@ -64,17 +64,13 @@ impl<'a> Diffable<'a, Package> for DbObject<'a> {
     ) -> PsqlpackResult<()> {
         match *self {
             DbObject::Column(table, column) => LinkedColumn { table: &table, column: &column }.generate(changeset, target, publish_profile, log),
-            DbObject::Constraint(table, constraint) => LinkedConstraint { table: &table, constraint: &constraint }.generate(changeset, target, publish_profile, log),
+            DbObject::Constraint(table, constraint) => LinkedTableConstraint { table: &table, constraint: &constraint }.generate(changeset, target, publish_profile, log),
             DbObject::Extension(extension) => extension.generate(changeset, target, publish_profile, log),
             DbObject::Function(function) => function.generate(changeset, target, publish_profile, log),
             DbObject::Schema(schema) => schema.generate(changeset, target, publish_profile, log),
             DbObject::Script(script) => script.generate(changeset, target, publish_profile, log),
             DbObject::Table(table) => table.generate(changeset, target, publish_profile, log),
             DbObject::Type(ty) => ty.generate(changeset, target, publish_profile, log),
-            ref unhandled => {
-                warn!(log, "TODO - unhandled DBObject: {}", unhandled);
-                Ok(())
-            }
         }
     }
 }
@@ -212,19 +208,20 @@ impl<'a> Diffable<'a, Package> for LinkedColumn<'a> {
     }
 }
 
-struct LinkedConstraint<'a> {
+struct LinkedTableConstraint<'a> {
     table: &'a TableDefinition,
     constraint: &'a TableConstraint
 }
 
-impl<'a> Diffable<'a, Package> for LinkedConstraint<'a> {
+impl<'a> Diffable<'a, Package> for LinkedTableConstraint<'a> {
     fn generate(
         &self,
         changeset: &mut Vec<ChangeInstruction<'a>>,
         _: &Package,
         _: &PublishProfile,
-        _: &Logger,
+        log: &Logger,
     ) -> PsqlpackResult<()> {
+        warn!(log, "TODO: Table constraints not yet implemented");
         Ok(())
     }
 }

--- a/psqlpack/src/model/delta.rs
+++ b/psqlpack/src/model/delta.rs
@@ -63,6 +63,8 @@ impl<'a> Diffable<'a, Package> for DbObject<'a> {
         log: &Logger,
     ) -> PsqlpackResult<()> {
         match *self {
+            DbObject::Column(table, column) => LinkedColumn { table: &table, column: &column }.generate(changeset, target, publish_profile, log),
+            DbObject::Constraint(table, constraint) => LinkedConstraint { table: &table, constraint: &constraint }.generate(changeset, target, publish_profile, log),
             DbObject::Extension(extension) => extension.generate(changeset, target, publish_profile, log),
             DbObject::Function(function) => function.generate(changeset, target, publish_profile, log),
             DbObject::Schema(schema) => schema.generate(changeset, target, publish_profile, log),
@@ -146,49 +148,83 @@ impl<'a> Diffable<'a, Package> for &'a TableDefinition {
     ) -> PsqlpackResult<()> {
         let table_result = target.tables.iter().find(|t| t.name == self.name);
         if let Some(target_table) = table_result {
-            // Check the columns
-
-            // Get all the differences
-            for src_column in self.columns.iter() {
-                let target_column = target_table.columns.iter().find(|tgt| tgt.name.eq(&src_column.name));
-                if let Some(target_column) = target_column {
-                    // Check the type
-                    if !src_column.sql_type.eq(&target_column.sql_type) {
-                        changeset.push(ChangeInstruction::ModifyColumnType(self, &src_column));
-                    }
-
-                    // Check constraints
-                    let src_set: HashSet<_> = src_column.constraints.iter().cloned().collect();
-                    let target_set: HashSet<_> = target_column.constraints.iter().cloned().collect();
-                    // target_set - src_set (e.g. adding new constraints)
-                    for x in target_set.difference(&src_set) {
-                        match *x {
-                            ColumnConstraint::Null | ColumnConstraint::NotNull => changeset.push(ChangeInstruction::ModifyColumnNull(self, &src_column)),
-                            ColumnConstraint::Default(_) => changeset.push(ChangeInstruction::ModifyColumnDefault(self, &src_column)),
-                            ColumnConstraint::Unique => changeset.push(ChangeInstruction::ModifyColumnUniqueConstraint(self, &src_column)),
-                            ColumnConstraint::PrimaryKey => changeset.push(ChangeInstruction::ModifyColumnPrimaryKeyConstraint(self, &src_column)),
-                        }
-                    }
-
-                    // TODO: src_sec - target_set (e.g. what's been removed)
-
-                } else {
-                    // Doesn't exist, add it
-                    changeset.push(ChangeInstruction::AddColumn(self, &src_column));
-                }
-            }
+            // We check for column removals here
             for tgt in target_table.columns.iter() {
                 if !self.columns.iter().any(|src| tgt.name.eq(&src.name)) {
                     // Column in target but not in source
                     changeset.push(ChangeInstruction::RemoveColumn(self, tgt.name.to_owned()));
                 }
             }
-
-            // TODO: Check the table constraints
-
         } else {
             changeset.push(ChangeInstruction::AddTable(self));
         }
+        Ok(())
+    }
+}
+
+struct LinkedColumn<'a> {
+    table: &'a TableDefinition,
+    column: &'a ColumnDefinition
+}
+
+impl<'a> Diffable<'a, Package> for LinkedColumn<'a> {
+    fn generate(
+        &self,
+        changeset: &mut Vec<ChangeInstruction<'a>>,
+        target: &Package,
+        _: &PublishProfile,
+        _: &Logger,
+    ) -> PsqlpackResult<()> {
+        // We only generate items here if the table doesn't exist (for the time being)
+        // We should consider if we want to just generate empty tables and then be consistent adding
+        let table_result = target.tables.iter().find(|t| t.name == self.table.name);
+        if let Some(target_table) = table_result {
+
+            // Check if the column exists on the target
+            let target_column = target_table.columns.iter().find(|tgt| tgt.name.eq(&self.column.name));
+            if let Some(target_column) = target_column {
+                // Check the type
+                if !self.column.sql_type.eq(&target_column.sql_type) {
+                    changeset.push(ChangeInstruction::ModifyColumnType(self.table, &self.column));
+                }
+
+                // Check constraints
+                let src_set: HashSet<_> = self.column.constraints.iter().cloned().collect();
+                let target_set: HashSet<_> = target_column.constraints.iter().cloned().collect();
+                // target_set - src_set (e.g. adding new constraints)
+                for x in target_set.difference(&src_set) {
+                    match *x {
+                        ColumnConstraint::Null | ColumnConstraint::NotNull => changeset.push(ChangeInstruction::ModifyColumnNull(self.table, &self.column)),
+                        ColumnConstraint::Default(_) => changeset.push(ChangeInstruction::ModifyColumnDefault(self.table, &self.column)),
+                        ColumnConstraint::Unique => changeset.push(ChangeInstruction::ModifyColumnUniqueConstraint(self.table, &self.column)),
+                        ColumnConstraint::PrimaryKey => changeset.push(ChangeInstruction::ModifyColumnPrimaryKeyConstraint(self.table, &self.column)),
+                    }
+                }
+
+                // TODO: src_sec - target_set (e.g. what constraints have been removed)
+
+            } else {
+                // Doesn't exist, add it
+                changeset.push(ChangeInstruction::AddColumn(self.table, &self.column));
+            }
+        }
+        Ok(())
+    }
+}
+
+struct LinkedConstraint<'a> {
+    table: &'a TableDefinition,
+    constraint: &'a TableConstraint
+}
+
+impl<'a> Diffable<'a, Package> for LinkedConstraint<'a> {
+    fn generate(
+        &self,
+        changeset: &mut Vec<ChangeInstruction<'a>>,
+        _: &Package,
+        _: &PublishProfile,
+        _: &Logger,
+    ) -> PsqlpackResult<()> {
         Ok(())
     }
 }
@@ -1325,8 +1361,7 @@ mod tests {
     fn it_can_add_column_to_existing_table() {
         let log = empty_logger();
         let mut source_table = base_table();
-        source_table.columns.push(
-            ColumnDefinition {
+        source_table.columns.push(ColumnDefinition {
                 name: "last_name".to_owned(),
                 sql_type: SqlType::Simple(SimpleSqlType::VariableLengthString(100)),
                 constraints: vec![
@@ -1346,7 +1381,13 @@ mod tests {
         };
 
         let mut changeset = Vec::new();
+        // First, check that source table changes do nothing
         let result = (&source_table).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        assert_that!(changeset).is_empty();
+
+        // Now we check with a linked column
+        let result = LinkedColumn { table: &source_table, column: &source_table.columns.last().unwrap()}
+                        .generate(&mut changeset, &existing_database, &publish_profile, &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to create a new table
@@ -1401,7 +1442,13 @@ mod tests {
         };
 
         let mut changeset = Vec::new();
+        // First, check that source table changes do nothing
         let result = (&source_table).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        assert_that!(changeset).is_empty();
+
+        // Now we check with a linked column
+        let result = LinkedColumn { table: &source_table, column: &source_table.columns.last().unwrap()}
+                        .generate(&mut changeset, &existing_database, &publish_profile, &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to create a new table

--- a/psqlpack/src/model/project.rs
+++ b/psqlpack/src/model/project.rs
@@ -8,7 +8,8 @@ use serde_json;
 use walkdir::WalkDir;
 
 use sql::ast::*;
-use sql::{lexer, parser};
+use sql::lexer;
+use sql::parser::StatementListParser;
 use model::Package;
 use errors::{PsqlpackError, PsqlpackResult, PsqlpackResultExt};
 use errors::PsqlpackErrorKind::*;
@@ -169,7 +170,7 @@ impl Project {
                 trace!(log, "Parsing file");
                 // TODO: In the future it'd be nice to allow the parser to generate
                 //       shift/reduce rules when dump-symbols is defined
-                match parser::parse_statement_list(tokens) {
+                match StatementListParser::new().parse(tokens) {
                     Ok(statement_list) => {
                         trace!(log, "Finished parsing statements"; "count" => statement_list.len());
                         for statement in statement_list {

--- a/psqlpack/src/sql/lexer.rs
+++ b/psqlpack/src/sql/lexer.rs
@@ -1,5 +1,4 @@
 use regex::Regex;
-use std::ascii::AsciiExt;
 use std::iter::FromIterator;
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/psqlpack/src/sql/parser.lalrpop
+++ b/psqlpack/src/sql/parser.lalrpop
@@ -98,27 +98,27 @@ extern {
     }
 }
 
-pub statement_list: Vec<Statement> = {
-    <v:statement_list> <stmt:statement> => {
+pub StatementList: Vec<Statement> = {
+    <v:StatementList> <stmt:Statement> => {
         let mut v = v;
         v.push(stmt);
         v
     },
-    <statement> => vec!(<>),
+    <Statement> => vec!(<>),
 };
 
-statement: Statement = {
+Statement: Statement = {
     CREATE EXTENSION <name:Ident> ";"? => Statement::Extension(ExtensionDefinition {
         name: name,
     }),
-    CREATE (OR REPLACE)? FUNCTION <name:object_name> "(" ")" RETURNS <return_type:function_return_type> AS <body:Literal> LANGUAGE <lang:function_type> ";"? => Statement::Function(FunctionDefinition {
+    CREATE (OR REPLACE)? FUNCTION <name:ObjectName> "(" ")" RETURNS <return_type:FunctionReturnType> AS <body:Literal> LANGUAGE <lang:FunctionType> ";"? => Statement::Function(FunctionDefinition {
         name: name,
         arguments: Vec::new(),
         return_type: return_type,
         body: body,
         language: lang,
     }),
-    CREATE (OR REPLACE)? FUNCTION <name:object_name> "(" <args:function_argument_list> ")" RETURNS <return_type:function_return_type> AS <body:Literal> LANGUAGE <lang:function_type> ";"? => Statement::Function(FunctionDefinition {
+    CREATE (OR REPLACE)? FUNCTION <name:ObjectName> "(" <args:FunctionArgumentList> ")" RETURNS <return_type:FunctionReturnType> AS <body:Literal> LANGUAGE <lang:FunctionType> ";"? => Statement::Function(FunctionDefinition {
         name: name,
         arguments: args,
         return_type: return_type,
@@ -128,51 +128,51 @@ statement: Statement = {
     CREATE SCHEMA <name:Ident> ";"? => Statement::Schema(SchemaDefinition {
         name: name,
     }),
-    CREATE TABLE <name:object_name> "(" <columns:column_definition_list> "," <table_constraints:table_constraint_list> ")" ";"? => Statement::Table(TableDefinition {
+    CREATE TABLE <name:ObjectName> "(" <columns:ColumnDefinitionList> "," <table_constraints:TableConstraintList> ")" ";"? => Statement::Table(TableDefinition {
         name: name,
         columns: columns,
         constraints: table_constraints,
     }),
-    CREATE TABLE <name:object_name> "(" <columns:column_definition_list> ")" ";"? => Statement::Table(TableDefinition {
+    CREATE TABLE <name:ObjectName> "(" <columns:ColumnDefinitionList> ")" ";"? => Statement::Table(TableDefinition {
         name: name,
         columns: columns,
         constraints: Vec::new(),
     }),
-    CREATE TYPE <name:Ident> AS ENUM "(" <values:enum_value_list> ")" ";"? => Statement::Type(TypeDefinition {
+    CREATE TYPE <name:Ident> AS ENUM "(" <values:EnumValueList> ")" ";"? => Statement::Type(TypeDefinition {
         name: name,
         kind: TypeDefinitionKind::Enum(values),
     }),
 };
 
-object_name: ObjectName = {
+ObjectName: ObjectName = {
     <schema:Ident> "." <name:Ident> => ObjectName { schema: Some(schema), name: name },
     <name:Ident> => ObjectName { schema: None, name: name },
 };
 
-column_definition_list: Vec<ColumnDefinition> = {
-    <v:column_definition_list> "," <c:column_definition> => {
+ColumnDefinitionList: Vec<ColumnDefinition> = {
+    <v:ColumnDefinitionList> "," <c:ColumnDefinition> => {
         let mut v = v;
         v.push(c);
         v
     },
-    <column_definition> => vec!(<>)
+    <ColumnDefinition> => vec!(<>)
 };
 
-column_definition: ColumnDefinition = {
-    <name:Ident> <t:sql_type> <constraints:column_constraint_list> => ColumnDefinition {
+ColumnDefinition: ColumnDefinition = {
+    <name:Ident> <t:SqlType> <constraints:ColumnConstraintList> => ColumnDefinition {
         name: name,
         sql_type: t,
         constraints: constraints,
     },
-    <name:Ident> <t:sql_type> => ColumnDefinition {
+    <name:Ident> <t:SqlType> => ColumnDefinition {
         name: name,
         sql_type: t,
         constraints: Vec::new(),
     },
 };
 
-column_list: Vec<String> = {
-    <v:column_list> "," <c:Ident> => {
+ColumnList: Vec<String> = {
+    <v:ColumnList> "," <c:Ident> => {
         let mut v = v;
         v.push(c);
         v
@@ -180,50 +180,50 @@ column_list: Vec<String> = {
     <Ident> => vec!(<>),
 };
 
-pub function_argument_list: Vec<FunctionArgument> = {
-    <v:function_argument_list> "," <a:function_argument> => {
+pub FunctionArgumentList: Vec<FunctionArgument> = {
+    <v:FunctionArgumentList> "," <a:FunctionArgument> => {
         let mut v = v;
         v.push(a);
         v
     },
-    <function_argument> => vec!(<>)
+    <FunctionArgument> => vec!(<>)
 };
 
-function_argument: FunctionArgument = {
-    <name:Ident> <t:sql_type> => FunctionArgument {
+FunctionArgument: FunctionArgument = {
+    <name:Ident> <t:SqlType> => FunctionArgument {
         name: name,
         sql_type: t,
     }
 };
 
-pub function_return_type: FunctionReturnType = {
-    TABLE "(" <columns:column_definition_list> ")" => FunctionReturnType::Table(columns),
-    <t:sql_type> => FunctionReturnType::SqlType(t),
+pub FunctionReturnType: FunctionReturnType = {
+    TABLE "(" <columns:ColumnDefinitionList> ")" => FunctionReturnType::Table(columns),
+    <t:SqlType> => FunctionReturnType::SqlType(t),
 };
 
-function_type: FunctionLanguage = {
+FunctionType: FunctionLanguage = {
     C => FunctionLanguage::C,
     INTERNAL => FunctionLanguage::Internal,
     PLPGSQL => FunctionLanguage::PostgreSQL,
     SQL => FunctionLanguage::SQL,
 };
 
-table_constraint_list: Vec<TableConstraint> = {
-    <v:table_constraint_list> "," <c:table_constraint> => {
+TableConstraintList: Vec<TableConstraint> = {
+    <v:TableConstraintList> "," <c:TableConstraint> => {
         let mut v = v;
         v.push(c);
         v
     },
-    <table_constraint> => vec!(<>),
+    <TableConstraint> => vec!(<>),
 };
 
-table_constraint: TableConstraint = {
-    CONSTRAINT <name:Ident> PRIMARY KEY "(" <columns:column_list> ")" <parameters:index_parameters?> => TableConstraint::Primary {
+TableConstraint: TableConstraint = {
+    CONSTRAINT <name:Ident> PRIMARY KEY "(" <columns:ColumnList> ")" <parameters:WithIndexParameters?> => TableConstraint::Primary {
         name: name,
         columns: columns,
         parameters: parameters
     },
-    CONSTRAINT <name:Ident> FOREIGN KEY "(" <columns:column_list> ")" REFERENCES <ref_table:object_name> "(" <ref_columns:column_list> ")" <match_type:match_type?> <events:constraint_events?> => TableConstraint::Foreign {
+    CONSTRAINT <name:Ident> FOREIGN KEY "(" <columns:ColumnList> ")" REFERENCES <ref_table:ObjectName> "(" <ref_columns:ColumnList> ")" <match_type:MatchType?> <events:ConstraintEventList?> => TableConstraint::Foreign {
         name: name,
         columns: columns,
         ref_table: ref_table,
@@ -233,44 +233,44 @@ table_constraint: TableConstraint = {
     },
 };
 
-index_parameters: Vec<IndexParameter> = {
-    WITH "(" <index_parameter_list> ")" => <>,
+WithIndexParameters: Vec<IndexParameter> = {
+    WITH "(" <IndexParameterList> ")" => <>,
 };
 
-index_parameter_list: Vec<IndexParameter> = {
-    <v:index_parameter_list> "," <i:index_parameter> => {
+IndexParameterList: Vec<IndexParameter> = {
+    <v:IndexParameterList> "," <i:IndexParameter> => {
         let mut v = v;
         v.push(i);
         v
     },
-    <index_parameter> => vec!(<>),
+    <IndexParameter> => vec!(<>),
 };
 
-index_parameter: IndexParameter = {
+IndexParameter: IndexParameter = {
     FILLFACTOR "=" <Digit> => IndexParameter::FillFactor(<> as u32),
 };
 
-match_type: ForeignConstraintMatchType = {
+MatchType: ForeignConstraintMatchType = {
     MATCH SIMPLE => ForeignConstraintMatchType::Simple,
     MATCH PARTIAL => ForeignConstraintMatchType::Partial,
     MATCH FULL => ForeignConstraintMatchType::Full,
 };
 
-constraint_events: Vec<ForeignConstraintEvent> = {
-    <v:constraint_events> <e:constraint_event> => {
+ConstraintEventList: Vec<ForeignConstraintEvent> = {
+    <v:ConstraintEventList> <e:ConstraintEvent> => {
         let mut v = v;
         v.push(e);
         v
     },
-    <constraint_event> => vec!(<>),
+    <ConstraintEvent> => vec!(<>),
 };
 
-constraint_event: ForeignConstraintEvent = {
-    ON DELETE <foreign_constraint_action> => ForeignConstraintEvent::Delete(<>),
-    ON UPDATE <foreign_constraint_action> => ForeignConstraintEvent::Update(<>),
+ConstraintEvent: ForeignConstraintEvent = {
+    ON DELETE <ForeignConstraintAction> => ForeignConstraintEvent::Delete(<>),
+    ON UPDATE <ForeignConstraintAction> => ForeignConstraintEvent::Update(<>),
 };
 
-foreign_constraint_action: ForeignConstraintAction = {
+ForeignConstraintAction: ForeignConstraintAction = {
     NO ACTION => ForeignConstraintAction::NoAction,
     RESTRICT => ForeignConstraintAction::Restrict,
     CASCADE => ForeignConstraintAction::Cascade,
@@ -278,14 +278,14 @@ foreign_constraint_action: ForeignConstraintAction = {
     SET DEFAULT => ForeignConstraintAction::SetDefault,
 };
 
-pub sql_type: SqlType = {
-    <simple_type> => SqlType::Simple(<>),
-    <simple:simple_type> <dim:array_dimension> => SqlType::Array(simple, dim),
+pub SqlType: SqlType = {
+    <SimpleType> => SqlType::Simple(<>),
+    <simple:SimpleType> <dim:ArrayDimension> => SqlType::Array(simple, dim),
     <Ident> => SqlType::Custom(<>, None),
     <name:Ident> "(" <options:Ident> ")" => SqlType::Custom(name, Some(options)),
 };
 
-simple_type: SimpleSqlType = {
+SimpleType: SimpleSqlType = {
     CHAR "(" <Digit> ")" => SimpleSqlType::FixedLengthString(<> as u32),
     CHARACTER "(" <Digit> ")" => SimpleSqlType::FixedLengthString(<> as u32),
     VARCHAR "(" <Digit> ")" => SimpleSqlType::VariableLengthString(<> as u32),
@@ -332,37 +332,37 @@ simple_type: SimpleSqlType = {
     UUID => SimpleSqlType::Uuid,
 };
 
-array_dimension: u32 = {
+ArrayDimension: u32 = {
     "[" "]" => 1u32,
-    <dim:array_dimension> "[" "]" => dim + 1u32,
+    <dim:ArrayDimension> "[" "]" => dim + 1u32,
 };
 
-column_constraint_list: Vec<ColumnConstraint> = {
-    <v:column_constraint_list> <q:column_constraint> => {
+ColumnConstraintList: Vec<ColumnConstraint> = {
+    <v:ColumnConstraintList> <q:ColumnConstraint> => {
         let mut v = v;
         v.push(q);
         v
     },
-    <column_constraint> => vec!(<>),
+    <ColumnConstraint> => vec!(<>),
 };
 
-column_constraint: ColumnConstraint = {
-    DEFAULT <any_value> => ColumnConstraint::Default(<>),
-    DEFAULT "(" <any_value> ")" => ColumnConstraint::Default(<>),
+ColumnConstraint: ColumnConstraint = {
+    DEFAULT <AnyValue> => ColumnConstraint::Default(<>),
+    DEFAULT "(" <AnyValue> ")" => ColumnConstraint::Default(<>),
     NULL => ColumnConstraint::Null,
     NOT NULL => ColumnConstraint::NotNull,
     UNIQUE => ColumnConstraint::Unique,
     PRIMARY KEY => ColumnConstraint::PrimaryKey,
 };
 
-any_value: AnyValue = {
+AnyValue: AnyValue = {
     <Boolean> => AnyValue::Boolean(<>),
     <Digit> => AnyValue::Integer(<>),
     <String> => AnyValue::String(<>),
 };
 
-enum_value_list: Vec<String> = {
-    <v:enum_value_list> "," <e:String> => {
+EnumValueList: Vec<String> = {
+    <v:EnumValueList> "," <e:String> => {
         let mut v = v;
         v.push(e);
         v


### PR DESCRIPTION
Closes #29 

`ColumnDefinition`s were previously being output however they were done completely within the `TableDefinition`. This caused a few issues in regards to log warnings as well as complicated the update process for existing columns.

This change teases this logic apart so that the column logic exists primarily within a column structure. The only exception to this is the removal of columns due to no object existing - this is still completed on the `TableDefinition`.

Amongst all of this, I updated `lalrpop` to `0.15`, fixed the compat issues and removed superfluous warnings. There are warnings remaining about unused `TableConstraint`s however these will be addressed with #30.