### PR TITLE
Loads Table Constraints from a database connection

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -185,7 +185,7 @@ fn main() {
                         .short("s")
                         .required(true)
                         .takes_value(true)
-                        .help("The source package to use for the deploy report"),
+                        .help("The source package or project file to use for the deploy report"),
                 )
                 .arg(
                     Arg::with_name("TARGET")
@@ -221,7 +221,7 @@ fn main() {
                         .short("s")
                         .required(false)
                         .takes_value(true)
-                        .help("The source package to use for the deploy report"),
+                        .help("The source package or project file to use for the deploy report"),
                 )
                 .arg(
                     Arg::with_name("TARGET")

--- a/psqlpack/src/errors.rs
+++ b/psqlpack/src/errors.rs
@@ -70,6 +70,9 @@ error_chain! {
         PackageQueryColumnsError {
             description("Couldn't query columns")
         }
+        PackageQueryTableConstraintsError {
+            description("Couldn't query table constraints")
+        }
         PackageFunctionArgsInspectError(args: String) {
             description("Couldn't inspect function args")
             display("Couldn't inspect function args: {}", args)

--- a/psqlpack/src/model/delta.rs
+++ b/psqlpack/src/model/delta.rs
@@ -244,7 +244,7 @@ impl<'a> Diffable<'a, Package> for LinkedTableConstraint<'a> {
             if src.is_some() && tgt.is_some() {
                 vec_different(src.as_ref().unwrap(), tgt.as_ref().unwrap())
             } else {
-                true
+                src.is_none() ^ tgt.is_none()
             }
         }
 
@@ -292,11 +292,15 @@ impl<'a> Diffable<'a, Package> for LinkedTableConstraint<'a> {
                                     ref match_type, 
                                     ref events 
                                 } => {
-                                    vec_different(src_columns, columns) ||
+                                    let match_type_different = if src_match_type.is_some() && match_type.is_some() {
+                                        src_match_type.as_ref().unwrap().ne(match_type.as_ref().unwrap())
+                                    } else {
+                                        src_match_type.is_none() ^ match_type.is_none()
+                                    };
+                                    match_type_different ||
+                                        vec_different(src_columns, columns) ||
                                         src_ref_table.ne(ref_table) ||
                                         vec_different(src_ref_columns, ref_columns) ||
-                                        ((src_match_type.is_none() || match_type.is_none()) || 
-                                            src_match_type.as_ref().unwrap().ne(match_type.as_ref().unwrap())) ||
                                         optional_vec_different(src_events, events)
                                 }
                             }

--- a/psqlpack/src/model/delta.rs
+++ b/psqlpack/src/model/delta.rs
@@ -303,13 +303,11 @@ impl<'a> Diffable<'a, Package> for LinkedTableConstraint<'a> {
                         }
                     };
                 if has_changed {
-                    trace!(_log, "Src: {:?}\n\nDest: {:?}", self.constraint, target_constraint);
                     changeset.push(ChangeInstruction::RemoveConstraint(self.table, self.constraint.name().to_owned()));
                     changeset.push(ChangeInstruction::AddConstraint(self.table, self.constraint));
                 }
             } else {
                 // Doesn't exist, add it
-                trace!(_log, "Removing: {:?}", self.constraint);
                 changeset.push(ChangeInstruction::AddConstraint(self.table, &self.constraint));
             }
 

--- a/psqlpack/src/model/delta.rs
+++ b/psqlpack/src/model/delta.rs
@@ -303,11 +303,13 @@ impl<'a> Diffable<'a, Package> for LinkedTableConstraint<'a> {
                         }
                     };
                 if has_changed {
+                    trace!(_log, "Src: {:?}\n\nDest: {:?}", self.constraint, target_constraint);
                     changeset.push(ChangeInstruction::RemoveConstraint(self.table, self.constraint.name().to_owned()));
                     changeset.push(ChangeInstruction::AddConstraint(self.table, self.constraint));
                 }
             } else {
                 // Doesn't exist, add it
+                trace!(_log, "Removing: {:?}", self.constraint);
                 changeset.push(ChangeInstruction::AddConstraint(self.table, &self.constraint));
             }
 

--- a/psqlpack/src/model/delta.rs
+++ b/psqlpack/src/model/delta.rs
@@ -865,6 +865,63 @@ impl<'input> ChangeInstruction<'input> {
                         }
                     }
                 }
+                // Add table constraints
+                for constraint in def.constraints.iter() {
+                    instr.push_str(",\n\t");
+                    match *constraint {
+                        TableConstraint::Primary {
+                            ref name,
+                            ref columns,
+                            ref parameters,
+                        } => {
+                            instr.push_str(&format!(
+                                "CONSTRAINT {} PRIMARY KEY ({})",
+                                name,
+                                columns.join(", ")
+                            ));
+
+                            // Do the WITH options too
+                            if let Some(ref unwrapped) = *parameters {
+                                instr.push_str(" WITH (");
+                                for (position, value) in unwrapped.iter().enumerate() {
+                                    if position > 0 {
+                                        instr.push_str(", ");
+                                    }
+                                    match *value {
+                                        IndexParameter::FillFactor(i) => instr.push_str(&format!("FILLFACTOR={}", i)[..]),
+                                    }
+                                }
+                                instr.push_str(")");
+                            }
+                        }
+                        TableConstraint::Foreign {
+                            ref name,
+                            ref columns,
+                            ref ref_table,
+                            ref ref_columns,
+                            ref match_type,
+                            ref events,
+                        } => {
+                            instr.push_str(&format!("CONSTRAINT {} FOREIGN KEY ({})", name, columns.join(", "))[..]);
+                            instr.push_str(&format!(" REFERENCES {} ({})", ref_table, ref_columns.join(", "))[..]);
+                            if let Some(ref m) = *match_type {
+                                instr.push_str(&format!(" {}", m));
+                            }
+                            if let Some(ref events) = *events {
+                                for e in events {
+                                    match *e {
+                                        ForeignConstraintEvent::Delete(ref action) => {
+                                            instr.push_str(&format!(" ON DELETE {}", action))
+                                        }
+                                        ForeignConstraintEvent::Update(ref action) => {
+                                            instr.push_str(&format!(" ON UPDATE {}", action))
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 instr.push_str("\n)");
                 instr
             }

--- a/psqlpack/src/model/package.rs
+++ b/psqlpack/src/model/package.rs
@@ -664,9 +664,12 @@ impl Package {
                     column.constraints.remove(pk_pos);
                     
                     // Add a table constraint if it doesn't exist
-                    let name = format!("{}_pkey", table.name.name);
-                    let found = table.constraints.iter().position(|c| c.name().eq(&name));
+                    let found = table.constraints.iter().position(|c| match c {
+                        TableConstraint::Primary { .. } => true,
+                        _ => false,
+                    });
                     if found.is_none() {
+                        let name = format!("{}_pkey", table.name.name);
                         table.constraints.push(TableConstraint::Primary {
                             name: name,
                             columns: vec![column.name.to_owned()],

--- a/psqlpack/tests/common/mod.rs
+++ b/psqlpack/tests/common/mod.rs
@@ -78,15 +78,14 @@ macro_rules! assert_simple_package {
         let table = table.unwrap();
         assert_that!(table.name.to_string()).is_equal_to(format!("{}.contacts", $namespace));
         assert_that!(table.columns).has_length(2);
-        assert_that!(table.constraints).is_empty();
+        assert_that!(table.constraints).has_length(1);
 
         // Validate the id column
         let col_id = &table.columns[0];
         assert_that!(col_id.name).is_equal_to("id".to_string());
         assert_that!(col_id.sql_type).is_equal_to(SqlType::Simple(SimpleSqlType::Serial));
-        assert_that!(col_id.constraints).has_length(2);
+        assert_that!(col_id.constraints).has_length(1);
         let constraints = col_id.constraints.iter();
-        assert_that!(constraints).contains(ColumnConstraint::PrimaryKey);
         assert_that!(constraints).contains(ColumnConstraint::NotNull);
 
         // Validate the name column


### PR DESCRIPTION
This allows table constraints to be loaded from the database correctly. In addition this:

* Fixes a bug whereby primary keys were mistakenly dropped. This was due to the implicit nature of the column constraint `PrimaryKey` (these are now promoted to Table Constraints in psqlpack)
* Fixes an issue where table constraints weren't put on new tables

Closes #99 