### PR TITLE
Added support for simple numeric types

### DIFF
--- a/psqlpack/src/sql/ast.rs
+++ b/psqlpack/src/sql/ast.rs
@@ -34,7 +34,7 @@ pub enum SimpleSqlType {
     Serial,      // serial
     BigSerial,   // bigserial
 
-    Numeric(u32, u32), // numeric(m,d)
+    Numeric(Option<(u32, u32)>), // numeric(m,d)
     Double,            // double precision
     Single,            // real
     Money,             // money
@@ -281,7 +281,8 @@ impl fmt::Display for SimpleSqlType {
             SimpleSqlType::Serial => write!(f, "serial"),
             SimpleSqlType::BigSerial => write!(f, "bigserial"),
 
-            SimpleSqlType::Numeric(m, d) => write!(f, "numeric({},{})", m, d),
+            SimpleSqlType::Numeric(Some((m, d))) => write!(f, "numeric({},{})", m, d),
+            SimpleSqlType::Numeric(None) => write!(f, "numeric"),
             SimpleSqlType::Double => write!(f, "double precision"),
             SimpleSqlType::Single => write!(f, "real"),
             SimpleSqlType::Money => write!(f, "money"),

--- a/psqlpack/src/sql/parser.lalrpop
+++ b/psqlpack/src/sql/parser.lalrpop
@@ -312,7 +312,9 @@ SimpleType: SimpleSqlType = {
     SERIAL4 => SimpleSqlType::Serial,
     SERIAL8 => SimpleSqlType::BigSerial,
 
-    NUMERIC "(" <m:Digit> "," <d:Digit> ")" => SimpleSqlType::Numeric(m as u32, d as u32),
+    NUMERIC => SimpleSqlType::Numeric(None),
+    NUMERIC "(" <m:Digit> ")" => SimpleSqlType::Numeric(Some((m as u32, 0))),
+    NUMERIC "(" <m:Digit> "," <d:Digit> ")" => SimpleSqlType::Numeric(Some((m as u32, d as u32))),
     DOUBLE PRECISION => SimpleSqlType::Double,
     REAL => SimpleSqlType::Single,
     MONEY => SimpleSqlType::Money,

--- a/samples/complex/local.publish
+++ b/samples/complex/local.publish
@@ -3,6 +3,7 @@
   "generationOptions": {
     "alwaysRecreateDatabase": false,
     "dropEnumValues": "Error",
+    "dropFunctions": "Error",
     "dropTables": "Error",
     "dropColumns": "Error",
     "dropPrimaryKeyConstraints": "Error",

--- a/samples/psqlpack.sh
+++ b/samples/psqlpack.sh
@@ -28,19 +28,19 @@ case $1 in
         ;;        
     publish)
         action="Publishing '$db'"
-        cargo run -p psqlpack-cli -- publish --source out/$db.psqlpack --target "host=$db.db;database=$db;userid=$username;tlsmode=none;" --profile samples/$db/local.publish --trace
+        cargo run -p psqlpack-cli -- publish --source out/$db.psqlpack --target "host=localhost;database=$db;userid=$username;tlsmode=none;" --profile samples/$db/local.publish --trace
         ;;
     script)
         action="Generating SQL for '$db'"
-        cargo run -p psqlpack-cli -- script --source out/$db.psqlpack --target "host=$db.db;database=$db;userid=$username;tlsmode=none;" --profile samples/$db/local.publish --output out/$db.sql --trace
+        cargo run -p psqlpack-cli -- script --source out/$db.psqlpack --target "host=localhost;database=$db;userid=$username;tlsmode=none;" --profile samples/$db/local.publish --output out/$db.sql --trace
         ;;
     report)
         action="Generating Report for '$db'"
-        cargo run -p psqlpack-cli -- report --source out/$db.psqlpack --target "host=$db.db;database=$db;userid=$username;tlsmode=none;" --profile samples/$db/local.publish --output out/$db.json --trace
+        cargo run -p psqlpack-cli -- report --source out/$db.psqlpack --target "host=localhost;database=$db;userid=$username;tlsmode=none;" --profile samples/$db/local.publish --output out/$db.json --trace
         ;;
     extract)
         action="Extracting psqlpack for '$db'"
-        cargo run -p psqlpack-cli -- extract --source "host=$db.db;database=$db;userid=$username;tlsmode=none;" --output out/${db}db.psqlpack --trace
+        cargo run -p psqlpack-cli -- extract --source "host=localhost;database=$db;userid=$username;tlsmode=none;" --output out/${db}db.psqlpack --trace
         ;;        
     unpack)
         action="Unpacking psqlpack for '$db'"

--- a/samples/simple/local.publish
+++ b/samples/simple/local.publish
@@ -3,6 +3,7 @@
   "generationOptions": {
     "alwaysRecreateDatabase": false,
     "dropEnumValues": "Error",
+    "dropFunctions": "Error",
     "dropTables": "Error",
     "dropColumns": "Error",
     "dropPrimaryKeyConstraints": "Error",

--- a/samples/simple/public/tables/public.tax_table.sql
+++ b/samples/simple/public/tables/public.tax_table.sql
@@ -1,3 +1,6 @@
 CREATE TABLE public.tax_table(
-	id serial primary key
+	id serial primary key,
+	amount1 numeric,
+	amount2 numeric(5),
+	amount3 numeric(6, 3)
 );

--- a/samples/trivial/local.publish
+++ b/samples/trivial/local.publish
@@ -3,6 +3,7 @@
   "generationOptions": {
     "alwaysRecreateDatabase": false,
     "dropEnumValues": "Error",
+    "dropFunctions": "Error",
     "dropTables": "Error",
     "dropColumns": "Error",
     "dropPrimaryKeyConstraints": "Error",


### PR DESCRIPTION
Closes #108 
Adds simple support for `numeric` types.

* `numeric(m, d)` works as before
* `numeric(m)` uses `0` for the scale as per the documentation
* `numeric` forgoes using any scale or precision