### PR TITLE
Implement indexes within Psqlpack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,7 @@ dependencies = [
  "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres-protocol 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,8 @@ endif
 build:
 	cargo build -p psqlpack-cli
 
+test:
+	cargo test -- --test-threads=1
+
 clean:
 	$(RM_BK)

--- a/psqlpack/Cargo.toml
+++ b/psqlpack/Cargo.toml
@@ -13,7 +13,7 @@ lazy_static = "0.2"
 lalrpop-util = "0.13"
 slog = { version = "2.1", features = ["max_level_trace", "release_max_level_trace"] }
 slog-stdlog = "3.0"
-postgres = "0.15"
+postgres = { version = "0.15", features = ["with-serde_json"] }
 regex = "0.2"
 serde = "1.0"
 serde_derive = "1.0"

--- a/psqlpack/src/connection.rs
+++ b/psqlpack/src/connection.rs
@@ -39,17 +39,17 @@ impl Connection {
     }
 
     pub fn connect_host(&self) -> ConnectionResult<PostgresConnection> {
-        Ok(try!(PostgresConnection::connect(
+        Ok(PostgresConnection::connect(
             self.uri.clone(),
             self.tls_mode()
-        )))
+        )?)
     }
 
     pub fn connect_database(&self) -> ConnectionResult<PostgresConnection> {
-        Ok(try!(PostgresConnection::connect(
+        Ok(PostgresConnection::connect(
             self.uri_with_database(),
             self.tls_mode()
-        )))
+        )?)
     }
 
     fn uri_with_database(&self) -> String {
@@ -106,7 +106,7 @@ impl FromStr for Connection {
         }
 
         // Make sure we have enough for a connection string
-        Ok(try!(builder.build()))
+        Ok(builder.build()?)
     }
 }
 

--- a/psqlpack/src/errors.rs
+++ b/psqlpack/src/errors.rs
@@ -73,6 +73,9 @@ error_chain! {
         PackageQueryTableConstraintsError {
             description("Couldn't query table constraints")
         }
+        PackageQueryIndexesError {
+            description("Couldn't query indexes")
+        }
         PackageFunctionArgsInspectError(args: String) {
             description("Couldn't inspect function args")
             display("Couldn't inspect function args: {}", args)

--- a/psqlpack/src/lib.rs
+++ b/psqlpack/src/lib.rs
@@ -26,6 +26,7 @@ pub use errors::*;
 mod connection;
 mod sql;
 mod model;
+mod semver;
 
 pub mod ast {
     pub use sql::ast::*;
@@ -33,6 +34,7 @@ pub mod ast {
 pub use connection::ConnectionBuilder;
 pub use errors::{PsqlpackErrorKind, PsqlpackResult};
 pub use model::{Delta, GenerationOptions, Package, Project, PublishProfile, Toggle, template};
+pub use semver::{Semver, ServerVersion};
 
 /// Allows usage of no logging, std `log`, or slog.
 pub enum LogConfig {

--- a/psqlpack/src/model/profiles.rs
+++ b/psqlpack/src/model/profiles.rs
@@ -48,9 +48,12 @@ pub struct GenerationOptions {
     /// Functions may not be intended to be deleted. If set to Allow, psqlpack will drop the function.
     /// Default: Error
     #[serde(rename = "dropFunctions")] pub drop_functions: Toggle,
+    /// Indexes may not be intended to be deleted. If set to Allow, psqlpack will drop the index.
+    /// Default: Allow
+    #[serde(rename = "dropIndexes")] pub drop_indexes: Toggle,
 
     /// Forces index changes to be made concurrently to avoid locking on table writes.
-    /// Default: false
+    /// Default: true
     #[serde(rename = "forceConcurrentIndexes")] pub force_concurrent_indexes: bool,
 }
 
@@ -67,8 +70,9 @@ impl Default for PublishProfile {
                 drop_primary_key_constraints: Toggle::Error,
                 drop_foreign_key_constraints: Toggle::Allow,
                 drop_functions: Toggle::Error,
+                drop_indexes: Toggle::Allow,
 
-                force_concurrent_indexes: false,
+                force_concurrent_indexes: true,
             },
         }
     }

--- a/psqlpack/src/model/profiles.rs
+++ b/psqlpack/src/model/profiles.rs
@@ -48,6 +48,10 @@ pub struct GenerationOptions {
     /// Functions may not be intended to be deleted. If set to Allow, psqlpack will drop the function.
     /// Default: Error
     #[serde(rename = "dropFunctions")] pub drop_functions: Toggle,
+
+    /// Forces index changes to be made concurrently to avoid locking on table writes.
+    /// Default: false
+    #[serde(rename = "forceConcurrentIndexes")] pub force_concurrent_indexes: bool,
 }
 
 impl Default for PublishProfile {
@@ -63,6 +67,8 @@ impl Default for PublishProfile {
                 drop_primary_key_constraints: Toggle::Error,
                 drop_foreign_key_constraints: Toggle::Allow,
                 drop_functions: Toggle::Error,
+
+                force_concurrent_indexes: false,
             },
         }
     }

--- a/psqlpack/src/model/project.rs
+++ b/psqlpack/src/model/project.rs
@@ -50,7 +50,7 @@ pub struct Project {
     /// An array of globs representing files/folders to be included within your project. Defaults to `["**/*.sql"]`.
     #[serde(rename = "fileIncludeGlobs", skip_serializing_if = "Option::is_none")] pub include_globs: Option<Vec<String>>,
 
-    /// An array of globs representing files/folders to be excluded within your project. 
+    /// An array of globs representing files/folders to be excluded within your project.
     #[serde(rename = "fileExcludeGlobs", skip_serializing_if = "Option::is_none")] pub exclude_globs: Option<Vec<String>>,
 }
 
@@ -209,6 +209,7 @@ impl Project {
                             match statement {
                                 Statement::Extension(_) => warn!(log, "Extension statement found, ignoring"),
                                 Statement::Function(function_definition) => package.push_function(function_definition),
+                                Statement::Index(index_definition) => package.push_index(index_definition),
                                 Statement::Schema(schema_definition) => package.push_schema(schema_definition),
                                 Statement::Table(table_definition) => package.push_table(table_definition),
                                 Statement::Type(type_definition) => package.push_type(type_definition),

--- a/psqlpack/src/semver.rs
+++ b/psqlpack/src/semver.rs
@@ -1,0 +1,95 @@
+use std::cmp;
+use std::fmt;
+use postgres::{Connection as PostgresConnection};
+use regex::Regex;
+
+use errors::PsqlpackResult;
+use errors::PsqlpackErrorKind::*;
+
+#[derive(Debug)]
+pub struct Semver {
+    major: u32,
+    minor: u32,
+    revision: u32,
+}
+
+impl Semver {
+    pub fn new(major: u32, minor: u32, rev: u32) -> Self {
+        Semver {
+            major: major,
+            minor: minor,
+            revision: rev,
+        }
+    }
+}
+
+impl fmt::Display for Semver {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.revision)
+    }
+}
+
+impl cmp::PartialEq for Semver {
+    fn eq(&self, other: &Semver) -> bool {
+        self.cmp(other) == cmp::Ordering::Equal
+    }
+}
+
+impl Eq for Semver {}
+
+impl cmp::PartialOrd for Semver {
+    fn partial_cmp(&self, other: &Semver) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl cmp::Ord for Semver {
+    fn cmp(&self, other: &Semver) -> cmp::Ordering {
+        if self.major > other.major {
+            return cmp::Ordering::Greater;
+        } else if self.major < other.major {
+            return cmp::Ordering::Less;
+        }
+
+        if self.minor > other.minor {
+            return cmp::Ordering::Greater;
+        } else if self.minor < other.minor {
+            return cmp::Ordering::Less;
+        }
+
+        if self.revision > other.revision {
+            return cmp::Ordering::Greater;
+        } else if self.revision < other.revision {
+            return cmp::Ordering::Less;
+        }
+
+        cmp::Ordering::Equal
+    }
+}
+
+pub trait ServerVersion {
+    fn server_version(&self) -> PsqlpackResult<Semver>;
+}
+
+lazy_static! {
+    static ref VERSION : Regex = Regex::new("(\\d+)\\.(\\d+)\\.(\\d+)").unwrap();
+}
+
+impl ServerVersion for PostgresConnection {
+    fn server_version(&self) -> PsqlpackResult<Semver> {
+        let rows = self.query("SELECT version();", &[])
+                      .map_err(|e| DatabaseError(format!("Failed to retrieve server version: {}", e)))?;
+        let row = rows.iter().last();
+        if let Some(row) = row {
+            let version: String = row.get(0);
+            let caps = VERSION.captures(&version[..]).unwrap();
+            Ok(Semver {
+                major: caps.get(1).unwrap().as_str().parse::<u32>().unwrap(),
+                minor: caps.get(2).unwrap().as_str().parse::<u32>().unwrap(),
+                revision: caps.get(3).unwrap().as_str().parse::<u32>().unwrap(),
+            })
+        } else {
+            bail!(DatabaseError("Failed to retrieve version from server".into()))
+        }
+    }
+}

--- a/psqlpack/src/sql/ast.rs
+++ b/psqlpack/src/sql/ast.rs
@@ -4,6 +4,7 @@ use std::fmt;
 pub enum Statement {
     Extension(ExtensionDefinition),
     Function(FunctionDefinition),
+    Index(IndexDefinition),
     Schema(SchemaDefinition),
     Table(TableDefinition),
     Type(TypeDefinition),
@@ -200,6 +201,44 @@ pub enum FunctionLanguage {
     Internal,
     PostgreSQL,
     SQL,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct IndexDefinition {
+    pub name: String,
+    pub table: ObjectName,
+    pub columns: Vec<IndexColumn>,
+
+    pub unique: bool,
+    pub index_type: Option<IndexType>,
+    pub storage_parameters: Option<Vec<IndexParameter>>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum IndexType {
+    BTree,
+    Hash,
+    Gist,
+    Gin,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct IndexColumn {
+    pub name: String,
+    pub order: Option<IndexOrder>,
+    pub null_position: Option<IndexPosition>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum IndexOrder {
+    Ascending,
+    Descending,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum IndexPosition {
+    First,
+    Last,
 }
 
 impl fmt::Display for AnyValue {

--- a/psqlpack/src/sql/ast.rs
+++ b/psqlpack/src/sql/ast.rs
@@ -125,6 +125,16 @@ pub struct ObjectName {
     pub name: String,
 }
 
+impl ObjectName {
+    pub fn schema(&self) -> &str {
+        if let Some(ref schema) = self.schema {
+            schema
+        } else {
+            ""
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub struct TableDefinition {
     pub name: ObjectName,
@@ -212,6 +222,20 @@ pub struct IndexDefinition {
     pub unique: bool,
     pub index_type: Option<IndexType>,
     pub storage_parameters: Option<Vec<IndexParameter>>,
+}
+
+impl IndexDefinition {
+    pub fn fully_qualified_name(&self) -> String {
+        format!("{}.{}", self.schema(), self.name)
+    }
+
+    pub fn is_same_index(&self, other: &IndexDefinition) -> bool {
+        self.name.eq(&other.name) && self.schema().eq(other.schema())
+    }
+
+    pub fn schema(&self) -> &str {
+        self.table.schema()
+    }
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/psqlpack/src/sql/lexer.rs
+++ b/psqlpack/src/sql/lexer.rs
@@ -5,11 +5,13 @@ use std::iter::FromIterator;
 pub enum Token {
     ACTION,
     AS,
+    ASC,
     BIGINT,
     BIGSERIAL,
     BIT,
     BOOL,
     BOOLEAN,
+    BTREE,
     C,
     CASCADE,
     CONSTRAINT,
@@ -19,13 +21,19 @@ pub enum Token {
     DATE,
     DEFAULT,
     DELETE,
+    DESC,
     DOUBLE,
     ENUM,
     EXTENSION,
     FILLFACTOR,
+    FIRST,
     FOREIGN,
     FULL,
     FUNCTION,
+    GIN,
+    GIST,
+    HASH,
+    INDEX,
     INT,
     INT2,
     INT4,
@@ -34,11 +42,13 @@ pub enum Token {
     INTERNAL,
     KEY,
     LANGUAGE,
+    LAST,
     MATCH,
     MONEY,
     NO,
     NOT,
     NULL,
+    NULLS,
     NUMERIC,
     ON,
     OR,
@@ -70,6 +80,7 @@ pub enum Token {
     TYPE,
     UNIQUE,
     UPDATE,
+    USING,
     UUID,
     VARBIT,
     VARCHAR,
@@ -162,11 +173,13 @@ fn create_token(value: String) -> Option<Token> {
     // Keywords
     match_keyword!(value, ACTION);
     match_keyword!(value, AS);
+    match_keyword!(value, ASC);
     match_keyword!(value, BIGINT);
     match_keyword!(value, BIGSERIAL);
     match_keyword!(value, BIT);
     match_keyword!(value, BOOL);
     match_keyword!(value, BOOLEAN);
+    match_keyword!(value, BTREE);
     match_keyword!(value, C);
     match_keyword!(value, CASCADE);
     match_keyword!(value, CONSTRAINT);
@@ -176,13 +189,19 @@ fn create_token(value: String) -> Option<Token> {
     match_keyword!(value, DATE);
     match_keyword!(value, DEFAULT);
     match_keyword!(value, DELETE);
+    match_keyword!(value, DESC);
     match_keyword!(value, DOUBLE);
     match_keyword!(value, ENUM);
     match_keyword!(value, EXTENSION);
     match_keyword!(value, FILLFACTOR);
+    match_keyword!(value, FIRST);
     match_keyword!(value, FOREIGN);
     match_keyword!(value, FULL);
     match_keyword!(value, FUNCTION);
+    match_keyword!(value, GIN);
+    match_keyword!(value, GIST);
+    match_keyword!(value, HASH);
+    match_keyword!(value, INDEX);
     match_keyword!(value, INT);
     match_keyword!(value, INT2);
     match_keyword!(value, INT4);
@@ -191,11 +210,13 @@ fn create_token(value: String) -> Option<Token> {
     match_keyword!(value, INTERNAL);
     match_keyword!(value, KEY);
     match_keyword!(value, LANGUAGE);
+    match_keyword!(value, LAST);
     match_keyword!(value, MATCH);
     match_keyword!(value, MONEY);
     match_keyword!(value, NO);
     match_keyword!(value, NOT);
     match_keyword!(value, NULL);
+    match_keyword!(value, NULLS);
     match_keyword!(value, NUMERIC);
     match_keyword!(value, ON);
     match_keyword!(value, OR);
@@ -227,6 +248,7 @@ fn create_token(value: String) -> Option<Token> {
     match_keyword!(value, TYPE);
     match_keyword!(value, UNIQUE);
     match_keyword!(value, UPDATE);
+    match_keyword!(value, USING);
     match_keyword!(value, UUID);
     match_keyword!(value, VARBIT);
     match_keyword!(value, VARCHAR);

--- a/psqlpack/src/sql/parser.lalrpop
+++ b/psqlpack/src/sql/parser.lalrpop
@@ -136,7 +136,7 @@ Statement: Statement = {
         body: body,
         language: lang,
     }),
-    CREATE <unique:UNIQUE?> INDEX <name:Ident> ON <table:ObjectName> <index_type:IndexType?> "(" <columns:IndexColumnList> ")" <storage_parameters:WithIndexParameters?> => Statement::Index(IndexDefinition {
+    CREATE <unique:UNIQUE?> INDEX <name:Ident> ON <table:ObjectName> <index_type:IndexType?> "(" <columns:IndexColumnList> ")" <storage_parameters:WithIndexParameters?> ";"? => Statement::Index(IndexDefinition {
         name: name,
         table: table,
         columns: columns,

--- a/psqlpack/src/sql/parser.lalrpop
+++ b/psqlpack/src/sql/parser.lalrpop
@@ -17,11 +17,13 @@ extern {
 
         ACTION => lexer::Token::ACTION,
         AS => lexer::Token::AS,
+        ASC => lexer::Token::ASC,
         BIGINT => lexer::Token::BIGINT,
         BIGSERIAL => lexer::Token::BIGSERIAL,
         BIT => lexer::Token::BIT,
         BOOL => lexer::Token::BOOL,
         BOOLEAN => lexer::Token::BOOLEAN,
+        BTREE => lexer::Token::BTREE,
         C => lexer::Token::C,
         CASCADE => lexer::Token::CASCADE,
         CONSTRAINT => lexer::Token::CONSTRAINT,
@@ -31,13 +33,19 @@ extern {
         DATE => lexer::Token::DATE,
         DEFAULT => lexer::Token::DEFAULT,
         DELETE => lexer::Token::DELETE,
+        DESC => lexer::Token::DESC,
         DOUBLE => lexer::Token::DOUBLE,
         ENUM => lexer::Token::ENUM,
         EXTENSION => lexer::Token::EXTENSION,
         FILLFACTOR => lexer::Token::FILLFACTOR,
+        FIRST => lexer::Token::FIRST,
         FOREIGN => lexer::Token::FOREIGN,
         FULL => lexer::Token::FULL,
         FUNCTION => lexer::Token::FUNCTION,
+        GIN => lexer::Token::GIN,
+        GIST => lexer::Token::GIST,
+        HASH => lexer::Token::HASH,
+        INDEX => lexer::Token::INDEX,
         INT => lexer::Token::INT,
         INT2 => lexer::Token::INT2,
         INT4 => lexer::Token::INT4,
@@ -46,11 +54,13 @@ extern {
         INTERNAL => lexer::Token::INTERNAL,
         KEY => lexer::Token::KEY,
         LANGUAGE => lexer::Token::LANGUAGE,
+        LAST => lexer::Token::LAST,
         MATCH => lexer::Token::MATCH,
         MONEY => lexer::Token::MONEY,
         NO => lexer::Token::NO,
         NOT => lexer::Token::NOT,
         NULL => lexer::Token::NULL,
+        NULLS => lexer::Token::NULLS,
         NUMERIC => lexer::Token::NUMERIC,
         ON => lexer::Token::ON,
         OR => lexer::Token::OR,
@@ -82,6 +92,7 @@ extern {
         TYPE => lexer::Token::TYPE,
         UNIQUE => lexer::Token::UNIQUE,
         UPDATE => lexer::Token::UPDATE,
+        USING => lexer::Token::USING,
         UUID => lexer::Token::UUID,
         VARBIT => lexer::Token::VARBIT,
         VARCHAR => lexer::Token::VARCHAR,
@@ -124,6 +135,14 @@ Statement: Statement = {
         return_type: return_type,
         body: body,
         language: lang,
+    }),
+    CREATE <unique:UNIQUE?> INDEX <name:Ident> ON <table:ObjectName> <index_type:IndexType?> "(" <columns:IndexColumnList> ")" <storage_parameters:WithIndexParameters?> => Statement::Index(IndexDefinition {
+        name: name,
+        table: table,
+        columns: columns,
+        unique: unique.is_some(),
+        index_type: index_type,
+        storage_parameters: storage_parameters,
     }),
     CREATE SCHEMA <name:Ident> ";"? => Statement::Schema(SchemaDefinition {
         name: name,
@@ -276,6 +295,42 @@ ForeignConstraintAction: ForeignConstraintAction = {
     CASCADE => ForeignConstraintAction::Cascade,
     SET NULL => ForeignConstraintAction::SetNull,
     SET DEFAULT => ForeignConstraintAction::SetDefault,
+};
+
+IndexColumnList: Vec<IndexColumn> = {
+    <v:IndexColumnList> "," <c:IndexColumn> => {
+        let mut v = v;
+        v.push(c);
+        v
+    },
+    <IndexColumn> => vec!(<>),
+};
+
+IndexColumn: IndexColumn = {
+    <name:Ident> <order:IndexOrder?> <pos:IndexNullPosition?> => {
+        IndexColumn {
+            name: name,
+            order: order,
+            null_position: pos,
+        }
+    }
+};
+
+IndexOrder: IndexOrder = {
+    ASC => IndexOrder::Ascending,
+    DESC => IndexOrder::Descending,
+};
+
+IndexNullPosition: IndexPosition = {
+    NULLS FIRST => IndexPosition::First,
+    NULLS LAST => IndexPosition::Last,
+};
+
+IndexType: IndexType = {
+    USING BTREE => IndexType::BTree,
+    USING HASH => IndexType::Hash,
+    USING GIST => IndexType::Gist,
+    USING GIN => IndexType::Gin,
 };
 
 pub SqlType: SqlType = {

--- a/samples/simple/public/tables/public.vendor.sql
+++ b/samples/simple/public/tables/public.vendor.sql
@@ -7,3 +7,5 @@ create table vendor (
 
     constraint fk_exp_organisation foreign key (org_sequence_id) references organisation (sequence_id)
 );
+
+CREATE UNIQUE INDEX idx_organisation_name ON vendor (name ASC NULLS LAST) WITH (FILLFACTOR = 50);


### PR DESCRIPTION
This implements basic Index creation with publish options for forcing concurrency. It partially implements #89 as index storage changes in 9.6.

Closes #104 