### PR TITLE
Introduce multiple PostgreSQL version tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+dist: trusty
 sudo: required
 
 rust:
@@ -7,17 +8,18 @@ rust:
   - nightly
 
 env:
-  - POSTGRESQL_VERSION=9.4 RUST_BACKTRACE=1
-  - POSTGRESQL_VERSION=9.5 RUST_BACKTRACE=1
-  - POSTGRESQL_VERSION=9.6 RUST_BACKTRACE=1
-  - POSTGRESQL_VERSION=10 RUST_BACKTRACE=1
-  - POSTGRESQL_VERSION=11 RUST_BACKTRACE=1
+  - POSTGRESQL_VERSION=9.4
+  - POSTGRESQL_VERSION=9.5
+  - POSTGRESQL_VERSION=9.6
+  - POSTGRESQL_VERSION=10
+  - POSTGRESQL_VERSION=11
 
 services:
   - docker
 
 before_install:
   - docker pull postgres:$POSTGRESQL_VERSION
+  - sudo /etc/init.d/postgresql stop
   - docker run -d postgres:$POSTGRESQL_VERSION
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ services:
 before_install:
   - docker pull postgres:$POSTGRESQL_VERSION
   - sudo /etc/init.d/postgresql stop
-  - docker run -d postgres:$POSTGRESQL_VERSION
+  - docker run -d -p 127.0.0.1:5432:5432 postgres:$POSTGRESQL_VERSION
 
 script:
   - cargo build --verbose --all --all-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,19 @@ rust:
   - beta
   - nightly
 
-addons:
-  postgresql: 9.4
+env:
+  - POSTGRESQL_VERSION=9.4 RUST_BACKTRACE=1
+  - POSTGRESQL_VERSION=9.5 RUST_BACKTRACE=1
+  - POSTGRESQL_VERSION=9.6 RUST_BACKTRACE=1
+  - POSTGRESQL_VERSION=10 RUST_BACKTRACE=1
+  - POSTGRESQL_VERSION=11 RUST_BACKTRACE=1
 
-before_script:
-  - "./.travis/setup.sh"
+services:
+  - docker
+
+before_install:
+  - docker pull postgres:$POSTGRESQL_VERSION
+  - docker run -d postgres:$POSTGRESQL_VERSION
 
 script:
   - cargo build --verbose --all --all-features

--- a/psqlpack/src/semver.rs
+++ b/psqlpack/src/semver.rs
@@ -72,24 +72,54 @@ pub trait ServerVersion {
 }
 
 lazy_static! {
-    static ref VERSION : Regex = Regex::new("(\\d+)\\.(\\d+)\\.(\\d+)").unwrap();
+    static ref VERSION : Regex = Regex::new("(\\d+)\\.(\\d+)(\\.(\\d+))?").unwrap();
+}
+
+fn parse_version_string(version: &str) -> Semver {
+    let caps = VERSION.captures(version).unwrap();
+    let major = caps.get(1).unwrap().as_str().parse::<u32>().unwrap();
+    let minor = caps.get(2).unwrap().as_str().parse::<u32>().unwrap();
+    let revision = if let Some(rev) = caps.get(4) {
+        rev.as_str().parse::<u32>().unwrap()
+    } else {
+        0
+    };
+    Semver {
+        major: major,
+        minor: minor,
+        revision: revision,
+    }
 }
 
 impl ServerVersion for PostgresConnection {
     fn server_version(&self) -> PsqlpackResult<Semver> {
-        let rows = self.query("SELECT version();", &[])
+        let rows = self.query("SHOW SERVER_VERSION;", &[])
                       .map_err(|e| DatabaseError(format!("Failed to retrieve server version: {}", e)))?;
         let row = rows.iter().last();
         if let Some(row) = row {
             let version: String = row.get(0);
-            let caps = VERSION.captures(&version[..]).unwrap();
-            Ok(Semver {
-                major: caps.get(1).unwrap().as_str().parse::<u32>().unwrap(),
-                minor: caps.get(2).unwrap().as_str().parse::<u32>().unwrap(),
-                revision: caps.get(3).unwrap().as_str().parse::<u32>().unwrap(),
-            })
+            Ok(parse_version_string(&version[..]))
         } else {
             bail!(DatabaseError("Failed to retrieve version from server".into()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_version_string;
+    use spectral::prelude::*;
+
+    #[test]
+    fn it_can_parse_version_strings() {
+        let tests = &[
+            ("10.4", "10.4.0"),
+            ("9.4.18", "9.4.18"),
+            ("9.6.9", "9.6.9"),
+        ];
+        for &(given, expected) in tests {
+            let parsed = parse_version_string(given);
+            assert_that!(parsed.to_string()).is_equal_to(expected.to_string());
         }
     }
 }

--- a/psqlpack/tests/common/mod.rs
+++ b/psqlpack/tests/common/mod.rs
@@ -20,9 +20,12 @@ macro_rules! create_db {
 }
 
 macro_rules! drop_table {
-    ($connection:expr, $name:expr) => {{
-        let cmd = format!("DROP TABLE IF EXISTS {}", $name);
-        $connection.batch_execute(&cmd).unwrap();
+    ($connection:expr, $schema:expr, $name:expr) => {{
+        let result = $connection.query("SELECT 1 FROM pg_namespace WHERE nspname = $1", &[&$schema]).unwrap();
+        if !result.is_empty() {
+            let cmd = format!("DROP TABLE IF EXISTS {}.{}", $schema, $name);
+            $connection.batch_execute(&cmd).unwrap();
+        }
     }};
 }
 

--- a/psqlpack/tests/common/mod.rs
+++ b/psqlpack/tests/common/mod.rs
@@ -10,6 +10,7 @@ macro_rules! drop_db {
 macro_rules! create_db {
     ($connection:expr) => {{
         let conn = $connection.connect_host().unwrap();
+        println!("PG Version: {}", conn.server_version().unwrap());
         let result = conn.query("SELECT 1 FROM pg_database WHERE datname=$1", &[&$connection.database()]).unwrap();
         if result.is_empty() {
             conn.batch_execute(&format!("CREATE DATABASE {}", $connection.database())).unwrap();

--- a/psqlpack/tests/publish.rs
+++ b/psqlpack/tests/publish.rs
@@ -64,7 +64,7 @@ fn it_can_add_a_new_table_to_an_existing_database() {
     // Preliminary: create a database with no tables
     let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
     let conn = create_db!(connection);
-    drop_table!(conn, format!("{}.contacts", NAMESPACE));
+    drop_table!(conn, NAMESPACE, "contacts");
     conn.finish().unwrap();
 
     // Publish with basic assert
@@ -81,7 +81,7 @@ fn it_can_add_a_new_column_to_an_existing_table() {
     // Preliminary: create a database with a partial table
     let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
     let conn = create_db!(connection);
-    drop_table!(conn, format!("{}.contacts", NAMESPACE));
+    drop_table!(conn, NAMESPACE, "contacts");
     conn.batch_execute(&format!("CREATE SCHEMA IF NOT EXISTS {}", NAMESPACE)).unwrap();
     conn.batch_execute(&format!("CREATE TABLE {}.contacts (id serial PRIMARY KEY NOT NULL)", NAMESPACE)).unwrap();
     conn.finish().unwrap();
@@ -100,7 +100,7 @@ fn it_can_modify_an_existing_column_on_a_table() {
     // Preliminary: create a database with a partial table
     let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
     let conn = create_db!(connection);
-    drop_table!(conn, format!("{}.contacts", NAMESPACE));
+    drop_table!(conn, NAMESPACE, "contacts");
     conn.batch_execute(&format!("CREATE SCHEMA IF NOT EXISTS {}", NAMESPACE)).unwrap();
     conn.batch_execute(&format!("CREATE TABLE {}.contacts (id serial PRIMARY KEY NOT NULL, name character varying(10) NULL)", NAMESPACE)).unwrap();
     conn.finish().unwrap();
@@ -119,7 +119,7 @@ fn it_can_drop_an_existing_column_on_a_table() {
     // Preliminary: create a database with a partial table
     let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
     let conn = create_db!(connection);
-    drop_table!(conn, format!("{}.contacts", NAMESPACE));
+    drop_table!(conn, NAMESPACE, "contacts");
     conn.batch_execute(&format!("CREATE SCHEMA IF NOT EXISTS {}", NAMESPACE)).unwrap();
     conn.batch_execute(&format!("CREATE TABLE {}.contacts (id serial PRIMARY KEY NOT NULL, name character varying(50) NOT NULL, last_name character varying(10))", NAMESPACE)).unwrap();
     conn.finish().unwrap();
@@ -138,7 +138,7 @@ fn it_can_add_a_new_index_to_an_existing_table() {
     // Preliminary: create a database with a table but no indexes
     let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
     let conn = create_db!(connection);
-    drop_table!(conn, format!("{}.contacts", NAMESPACE));
+    drop_table!(conn, NAMESPACE, "contacts");
     conn.batch_execute(&format!("CREATE SCHEMA IF NOT EXISTS {}", NAMESPACE)).unwrap();
     conn.batch_execute(&format!("CREATE TABLE {}.contacts (id serial PRIMARY KEY NOT NULL, name character varying(50) NULL)", NAMESPACE)).unwrap();
     conn.finish().unwrap();
@@ -157,7 +157,7 @@ fn it_can_modify_an_index_on_a_table() {
     // Preliminary: create a database with a table but a broad index
     let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
     let conn = create_db!(connection);
-    drop_table!(conn, format!("{}.contacts", NAMESPACE));
+    drop_table!(conn, NAMESPACE, "contacts");
     conn.batch_execute(&format!("CREATE SCHEMA IF NOT EXISTS {}", NAMESPACE)).unwrap();
     conn.batch_execute(&format!("CREATE TABLE {}.contacts (id serial PRIMARY KEY NOT NULL, name character varying(50) NULL, name2 character varying(50) NULL)", NAMESPACE)).unwrap();
     conn.batch_execute(&format!("CREATE INDEX idx_contacts_name ON {}.contacts (name, name2)", NAMESPACE)).unwrap();
@@ -177,7 +177,7 @@ fn it_can_drop_an_index_on_a_table() {
     // Preliminary: create a database with a table and extra index
     let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
     let conn = create_db!(connection);
-    drop_table!(conn, format!("{}.contacts", NAMESPACE));
+    drop_table!(conn, NAMESPACE, "contacts");
     conn.batch_execute(&format!("CREATE SCHEMA IF NOT EXISTS {}", NAMESPACE)).unwrap();
     conn.batch_execute(&format!("CREATE TABLE {}.contacts (id serial PRIMARY KEY NOT NULL, name character varying(50) NOT NULL, name2 character varying(50) NULL)", NAMESPACE)).unwrap();
     conn.batch_execute(&format!("CREATE INDEX idx_contacts_name ON {}.contacts (name)", NAMESPACE)).unwrap();


### PR DESCRIPTION
This is largely a travis change which allows the code to be tested against multiple versions of PostgreSQL. This uncovered an issue with Semver processing whereby version 10.4 didn't include a revision and 11 (beta) didn't include a minor version or revision (understandably).

Tests take much longer however also have more coverage. The minimum supported version at present is 9.4. 

Closes #89