### PR TITLE
Basic Extension support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out
 .DS_Store
 *.bk
 .vscode
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking Changes
 
-* Extensions in project file are now in the form `{ "name": "ext" }`. If you are using this construct then you'll need to manually modify the project format.
+* Extensions in project file are now in the form `{ "name": "ext" }`. If you are using this construct then you'll need to manually modify the project format. Going forward, Extensions will not be parsed from SQL files (a warning will be generated).
 
 ### New
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## Version 0.3
+## vNext
 
 ### Breaking Changes
 
 * Extensions in project file are now in the form `{ "name": "ext" }`. If you are using this construct then you'll need to manually modify the project format.
+
+### New
+
+* Extensions are now supported during publish.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## Version 0.3
+
+### Breaking Changes
+
+* Extensions in project file are now in the form `{ "name": "ext" }`. If you are using this construct then you'll need to manually modify the project format.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,24 +1,27 @@
 [[package]]
 name = "adler32"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "aho-corasick"
-version = "0.6.4"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ansi_term"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "arrayref"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -31,43 +34,33 @@ dependencies = [
 
 [[package]]
 name = "atty"
-version = "0.1.2"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.16"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -75,26 +68,26 @@ name = "base64"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bit-set"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-vec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -102,13 +95,32 @@ name = "block-buffer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-padding 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "build_const"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -117,26 +129,31 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "byte-tools"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
-version = "1.2.1"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.4.6"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bzip2"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bzip2-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -144,42 +161,51 @@ name = "bzip2-sys"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.4"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.2"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.4.0"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clap"
-version = "2.30.0"
+version = "2.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -189,10 +215,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "crc"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -216,45 +242,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "digest"
-version = "0.7.2"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "docopt"
-version = "0.8.3"
+name = "digest"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "dtoa"
-version = "0.4.2"
+name = "docopt"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "either"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ena"
-version = "0.5.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "error-chain"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -264,21 +296,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fallible-iterator"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fixedbitset"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flate2"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "miniz_oxide_c_api 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz_oxide_c_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -286,7 +318,7 @@ name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -300,7 +332,15 @@ name = "generic-array"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -319,7 +359,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -327,19 +367,19 @@ name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "isatty"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -347,12 +387,12 @@ name = "itertools"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -366,45 +406,23 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-set 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ena 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ena 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-snap 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-util 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "lalrpop-snap"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "ena 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-util 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -412,12 +430,7 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "lalrpop-util"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -427,12 +440,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.37"
+version = "0.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -440,25 +453,25 @@ name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "matches"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "md5"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -466,45 +479,45 @@ name = "memchr"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "miniz_oxide_c_api"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "miniz_oxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz_oxide 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "msdos_time"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -520,49 +533,49 @@ name = "num"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-bigint"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.36"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.35"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -570,14 +583,19 @@ name = "num-rational"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "opaque-debug"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -588,36 +606,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "petgraph"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "phf"
-version = "0.7.21"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.7.21"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.7.21"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -630,12 +648,12 @@ name = "postgres"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fallible-iterator 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-iterator 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres-protocol 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "postgres-shared 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "socket2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "postgres-shared 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -644,28 +662,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fallible-iterator 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-iterator 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "md5 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stringprep 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "postgres-shared"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fallible-iterator 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-iterator 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres-protocol 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -675,7 +693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.3.8"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -685,44 +703,39 @@ dependencies = [
 name = "psqlpack"
 version = "0.1.0"
 dependencies = [
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-util 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-stdlog 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spectral 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zip 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zip 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "psqlpack-cli"
 version = "0.1.0"
 dependencies = [
- "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "psqlpack 0.1.0",
- "slog 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-term 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "quote"
-version = "0.5.2"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -731,23 +744,48 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "rand"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "redox_syscall"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -755,34 +793,42 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.2.6"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.4.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
 version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ryu"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -792,58 +838,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.27"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.27"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_internals 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.10"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "sha2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "siphasher"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "slog"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -853,7 +900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -863,30 +910,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "slog-term"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "isatty 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.3.2"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -902,24 +950,24 @@ name = "string_cache"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "new_debug_unreachable 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "phf_generator 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_generator 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -934,13 +982,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
@@ -949,20 +992,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.11.11"
+version = "0.15.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -975,12 +1010,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "term_size"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -989,42 +1033,46 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thread_local"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.39"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.9.0"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ucd-util"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1032,22 +1080,17 @@ name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1065,12 +1108,17 @@ dependencies = [
 
 [[package]]
 name = "utf8-ranges"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vec_map"
-version = "0.8.0"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1085,7 +1133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1109,152 +1157,158 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "zip"
-version = "0.2.8"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bzip2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "msdos_time 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
-"checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
-"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
-"checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
-"checksum arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd1479b7c29641adbd35ff3b5c293922d696a92f25c8c975da3e0acbc87258f"
+"checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
+"checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b385d69402821a1c254533a011a312531cbcc0e3e24f19bbb4747a5a2daf37e2"
-"checksum atty 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0fd4c0631f06448cc45a6bbb3b710ebb7ff8ccb96a0800c994afe23a70d5df2"
-"checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
-"checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
-"checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
+"checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
-"checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
-"checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
-"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+"checksum bit-set 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f1efcc46c18245a69c38fcc5cc650f16d3a59d034f3106e9ed63748f695730a"
+"checksum bit-vec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4440d5cb623bb7390ae27fec0bb6c61111969860f8e3ae198bfa0663645e67cf"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
-"checksum build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e90dc84f5e62d2ebe7676b83c22d33b6db8bd27340fb6ffbff0a364efa0cb9c9"
+"checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
+"checksum block-padding 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc4358306e344bf9775d0197fd00d2603e5afb0771bb353538630f022068ea3"
+"checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
-"checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
-"checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
-"checksum bzip2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3eafc42c44e0d827de6b1c131175098fe7fb53b8ce8a47e65cb3ea94688be24"
+"checksum byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "980479e6fde23246dfb54d47580d66b4e99202e7579c5eaa9fe10ecb5ebd2182"
+"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
+"checksum bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ce55bd354b095246fc34caf4e9e242f5297a7fd938b090cadfea6eee614aa62"
+"checksum bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
 "checksum bzip2-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2c5162604199bbb17690ede847eaa6120a3f33d5ab4dcc8e7c25b16d849ae79b"
-"checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
-"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
-"checksum clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c07b9257a00f3fc93b7f3c417fc15607ec7a56823bc2c37ec744e266387de5b"
+"checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
+"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+"checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
-"checksum crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5d02c0aac6bd68393ed69e00bbc2457f3e89075c6349db7189618dc4ddc1d7"
+"checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
 "checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
-"checksum digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "00a49051fef47a72c9623101b19bd71924a45cca838826caae3eaa4d00772603"
-"checksum docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8acd393692c503b168471874953a2531df0e9ab77d0b6bbc582395743300a4a"
-"checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
-"checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
-"checksum ena 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe5a5078ac8c506d3e4430763b1ba9b609b1286913e7d08e581d1c2de9b7e5"
-"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
+"checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
+"checksum docopt 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db2906c2579b5b7207fc1e328796a9a8835dc44e22dbe8e460b1d636f9a7b225"
+"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
+"checksum ena 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "25b4e5febb25f08c49f1b07dc33a182729a6b21edfb562b5aef95f78e0dbe5bb"
+"checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum fallible-iterator 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6034a9c9dfce417c7710128d202eef406878cd2fe294e76e2ee05259c9b042d"
-"checksum fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
-"checksum flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fac2277e84e5e858483756647a9d0aa8d9a2b7cba517fd84325a0aaa69a0909"
+"checksum fallible-iterator 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea79295a7a3e0d77f19e763cf1fe7189cd95fc2b36735ea0ea6b711a7380f509"
+"checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
+"checksum flate2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3b0c7353385f92079524de3b7116cf99d73947c08a7472774e9b3b04bff3b901"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum isatty 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f2a233726c7bb76995cec749d59582e5664823b7245d4970354408f1d79a7a2"
+"checksum isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
-"checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
+"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lalrpop 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ba451f7bd819b7afc99d4cf4bdcd5a4861e64955ba9680ac70df3a50625ad6cf"
-"checksum lalrpop-snap 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "60013fd6be14317d43f47658b1440956a9ca48a9ed0257e0e0a59aac13e43a1f"
-"checksum lalrpop-util 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7c7743f235fc17f5f50f3b1e64a8690ee154f17f86bd68cbb78787c5b37907f7"
-"checksum lalrpop-util 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "60c6c48ba857cd700673ce88907cadcdd7e2cd7783ed02378537c5ffd4f6460c"
+"checksum lalrpop 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2c226388f060de3853c2e4e78ee68fa9038cfc65fcc8f025ce3ef92476cc8772"
+"checksum lalrpop-util 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7c4eb3e3b8cd41d58f0f5aff3b10c3d394c0d0f09bea59c571f1a8371cf2cf28"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
-"checksum libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)" = "56aebce561378d99a0bb578f8cb15b6114d2a1814a6c7949bbe646d968bb4fa9"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
+"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-"checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
-"checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
-"checksum md5 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "daa1004633f76cdcd5a9d83ffcfe615e30ca7a2a638fcc8b8039a2dac21289d7"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+"checksum md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
-"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
-"checksum miniz_oxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aaa2d3ad070f428fffbd7d3ca2ea20bb0d8cffe9024405c44e1840bc1418b398"
-"checksum miniz_oxide_c_api 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "92d98fdbd6145645828069b37ea92ca3de225e000d80702da25c20d3584b38a5"
-"checksum msdos_time 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "65ba9d75bcea84e07812618fedf284a64776c2f2ea0cad6bca7f69739695a958"
+"checksum memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a3eb002f0535929f1199681417029ebea04aadc0c7a4224b46be99c7f5d6a16"
+"checksum miniz_oxide 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ad30a47319c16cde58d0314f5d98202a80c9083b5f61178457403dfb14e509c"
+"checksum miniz_oxide_c_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "28edaef377517fd9fe3e085c37d892ce7acd1fbeab9239c5a36eec352d8a8b7e"
+"checksum msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729"
 "checksum new_debug_unreachable 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0cdc457076c78ab54d5e0d6fa7c47981757f1e34dc39ff92787f217dede586c4"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
-"checksum num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "81b483ea42927c463e191802e7334556b48e7875297564c0e9951bd3a0ae53e3"
-"checksum num-complex 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "26ff8edeab9f1d8cf6b595e35138c2a389ea29f4f57a0e6bc44abf406e4b0077"
-"checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
-"checksum num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "4b226df12c5a59b63569dd57fafb926d91b385dfce33d8074a412411b689d593"
+"checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
+"checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+"checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
 "checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
-"checksum num-traits 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3c2bd9b9d21e48e956b763c9f37134dc62d9e95da6edb3f672cacb6caf3cd3"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum opaque-debug 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "51ecbcb821e1bd256d456fe858aaa7f380b63863eab2eb86eee1bd9f33dd6682"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
-"checksum petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7e5234c228fbfa874c86a77f685886127f82e0aef602ad1d48333fcac6ad61"
-"checksum phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "cb325642290f28ee14d8c6201159949a872f220c62af6e110a56ea914fbe42fc"
-"checksum phf_generator 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6b07ffcc532ccc85e3afc45865469bf5d9e4ef5bfcf9622e3cfe80c2d275ec03"
-"checksum phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "07e24b0ca9643bdecd0632f2b3da6b1b89bbb0030e0b992afc1113b23a7bc2f2"
+"checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
+"checksum phf 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "cec29da322b242f4c3098852c77a0ca261c9c01b806cae85a5572a1eb94db9a6"
+"checksum phf_generator 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "03dc191feb9b08b0dc1330d6549b795b9d81aec19efe6b4a45aec8d4caee0c4b"
+"checksum phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "b539898d22d4273ded07f64a05737649dc69095d92cb87c7097ec68e3f150b93"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 "checksum postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "115dde90ef51af573580c035857badbece2aa5cde3de1dfb3c932969ca92a6c5"
 "checksum postgres-protocol 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2487e66455bf88a1b247bf08a3ce7fe5197ac6d67228d920b0ee6a0e97fd7312"
-"checksum postgres-shared 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bafecadf25b7de9a5f747e93073db444c9ddcc7b3ae37bcdf63c2508f9a17f2d"
+"checksum postgres-shared 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ffac35b3e0029b404c24a3b82149b4e904f293e8ca4a327eefa24d3ca50df36f"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
-"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
+"checksum proc-macro2 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)" = "ab2fc21ba78ac73e4ff6b3818ece00be4e175ffbef4d0a717d978b48b24150c4"
+"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
-"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
-"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
+"checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
+"checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
+"checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
+"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5be5347bde0c48cfd8c3fdc0766cdfe9d8a755ef84d620d6794c778c91de8b2b"
-"checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
-"checksum rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11fb43a206a04116ffd7cfcf9bcb941f8eb6cc7ff667272246b0a1c74259a3cb"
+"checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
+"checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
+"checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
-"checksum serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "db99f3919e20faa51bb2996057f5031d8685019b5a06139b1ce761da671b8526"
-"checksum serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ba7591cfe93755e89eeecdbcc668885624829b020050e6aec99c2a03bd3fd0"
-"checksum serde_derive_internals 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6e03f1c9530c3fb0a0a5c9b826bdd9246a5921ae995d75f512ac917fc4dd55b5"
-"checksum serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "57781ed845b8e742fc2bf306aba8e3b408fe8c366b900e3769fbc39f49eb8b39"
-"checksum sha2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7daca11f2fdb8559c4f6c588386bed5e2ad4b6605c1442935a7f08144a918688"
-"checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
-"checksum slog 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a6b13b17f4225771f7f15cece704a4e68d3a5f31278ed26367f497133398a18"
+"checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
+"checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
+"checksum serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811"
+"checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
+"checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
+"checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+"checksum slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e1a2eec401952cd7b12a84ea120e2d57281329940c3f93c2bf04f462539508e"
 "checksum slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "053344c94c0e2b22da6305efddb698d7c485809427cf40555dc936085f67a9df"
 "checksum slog-stdlog 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ac42f8254ae996cc7d640f9410d3b048dcdf8887a10df4d5d4c44966de24c4a8"
-"checksum slog-term 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5bb5d9360b2b279b326824b3b4ca2402ead8a8138f0e5ec1900605c861bb6671"
-"checksum socket2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "630d23c56fe67dc851155459ed2ad37c5112e3877855b666970e08e5ad08a7fb"
+"checksum slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5951a808c40f419922ee014c15b6ae1cd34d963538b57d8a4778b9ca3fff1e0b"
+"checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
 "checksum spectral 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
 "checksum string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25d70109977172b127fe834e5449e5ab1740b9ba49fa18a2020f509174f25423"
-"checksum string_cache_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "35293b05cf1494e8ddd042a7df6756bf18d07f42d234f32e71dce8a7aabb0191"
+"checksum string_cache_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eea1eee654ef80933142157fdad9dd8bc43cf7c74e999e369263496f04ff4da"
 "checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
 "checksum stringprep 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
-"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)" = "90c39a061e2f412a9f869540471ab679e85e50c6b05604daf28bc3060f75c430"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
+"checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
-"checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
-"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
-"checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
-"checksum typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a99dc6780ef33c78780b826cf9d2a78840b72cae9474de4bcaf9051e60ebbd"
+"checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+"checksum ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0f8bfa9ff0cadcd210129ad9d2c5f145c13e9ced3d3e5d948a6213487d52444"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
-"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
-"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
+"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
-"checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
+"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum zip 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "e7341988e4535c60882d5e5f0b7ad0a9a56b080ade8bdb5527cb512f7b2180e0"
+"checksum zip 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "36b9e08fb518a65cf7e08a1e482573eb87a2f4f8c6619316612a3c1f162fe822"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,9 +10,9 @@ name = "psqlpack"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "2.26", features = [ "wrap_help" ] }
-slog = "2.1"
-slog-term = "2.3"
+clap = { version = "2.32", features = [ "wrap_help" ] }
+slog = "2.4"
+slog-term = "2.4"
 psqlpack = { path = "../psqlpack/" }
 
 [features]

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,9 +31,16 @@ The project file is a JSON formatted file which defines how to interpret the fil
 | `defaultSchema`     | Yes        | `string`   | The default schema to be assumed for the database (if none specified).
 | `preDeployScripts`  | Yes        | `[string]` | An array of relative paths to SQL scripts to be applied before deployment begins.
 | `postDeployScripts` | Yes        | `[string]` | An array of relative paths to SQL scripts to be applied after deployment finishes.
-| `extensions`        | No         | `[string]` | An array of extensions that are required for this project to function. e.g. `postgis`
+| `extensions`        | No         | [`[Extension]`](#extension) | An array of extensions that are required for this project to function. 
 | `fileIncludeGlobs`  | No         | `[string]` | An array of globs representing files/folders to be included within your project. Defaults to `["**/*.sql"]`.
 | `fileExcludeGlobs`  | No         | `[string]` | An array of globs representing files/folders to be excluded within your project.
+
+### Extension
+
+| Property  | Required   | Type     | Description 
+|-----------|------------|----------|-------------
+| `name`    | Yes        | `string` | The name of the extension. e.g. `postgis`
+| `version` | No         | `string` | The semver of the extension that you'd like installed. If absent, it will use the latest version of what is available on the server.
 
 ### Example
 
@@ -46,7 +53,8 @@ The project file is a JSON formatted file which defines how to interpret the fil
         "./scripts/seed/*.sql"
     ],
     "extensions": [
-        "postgis"
+        { "name": "postgis", "version": "2.3.7" },
+        { "name": "postgis_topology" }
     ]
 }
 ```

--- a/psqlpack/Cargo.toml
+++ b/psqlpack/Cargo.toml
@@ -7,22 +7,22 @@ license = "MIT/Apache-2.0"
 readme = "../README.md"
 
 [dependencies]
-error-chain = "0.11"
+error-chain = "0.12"
 glob = "0.2"
-lazy_static = "0.2"
-lalrpop-util = "0.13"
-slog = { version = "2.1", features = ["max_level_trace", "release_max_level_trace"] }
+lazy_static = "1.2"
+lalrpop-util = "0.16"
+slog = { version = "2.4", features = ["max_level_trace", "release_max_level_trace"] }
 slog-stdlog = "3.0"
 postgres = { version = "0.15", features = ["with-serde_json"] }
-regex = "0.2"
+regex = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-zip = "0.2"
+zip = "0.4"
 petgraph = "0.4"
 
 [build-dependencies]
-lalrpop = "0.15"
+lalrpop = "0.16"
 
 [dev-dependencies]
 spectral = "0.6.0"

--- a/psqlpack/build.rs
+++ b/psqlpack/build.rs
@@ -1,5 +1,8 @@
 extern crate lalrpop;
 
 fn main() {
-    lalrpop::process_root().unwrap();
+    lalrpop::Configuration::new()
+        .generate_in_source_tree()
+        .process()
+        .unwrap();
 }

--- a/psqlpack/src/errors.rs
+++ b/psqlpack/src/errors.rs
@@ -89,7 +89,7 @@ error_chain! {
             display("Couldn't publish database due to an invalid operation: {}", message)
         }
         PublishUnsafeOperationError(message: String) {
-            description("Couldn't publish database due to an unsafe operation")
+            description("Unsafe Operation")
             display("Couldn't publish database due to an unsafe operation: {}", message)
         }
         GlobPatternError(err: PatternError) {

--- a/psqlpack/src/errors.rs
+++ b/psqlpack/src/errors.rs
@@ -151,6 +151,10 @@ error_chain! {
             description("Project format error")
             display("Project format error: {}", message)
         }
+        PublishError(message: String) {
+            description("Publish error")
+            display("Publish error: {}", message)
+        }
         MultipleErrors(errors: Vec<PsqlpackError>) {
             description("Multiple errors")
             display("Multiple errors:\n{}", MultipleErrorFormatter(errors))

--- a/psqlpack/src/errors.rs
+++ b/psqlpack/src/errors.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use glob::PatternError;
 
+pub use ast::ErrorKind;
 pub use error_chain::ChainedError;
 pub use lalrpop_util::ParseError;
 pub use model::ValidationKind;
@@ -52,7 +53,7 @@ error_chain! {
             description("Couldn't read part of the package file")
             display("Couldn't read part of the package file: {}", file_name)
         }
-        PackageQueryExtensionsError {
+        QueryExtensionsError {
             description("Couldn't query extensions")
         }
         PackageQuerySchemasError {
@@ -118,6 +119,10 @@ error_chain! {
         InlineParseError(error: ParseError<(), lexer::Token, &'static str>) {
             description("Parser error")
             display("Parser error: {}", ParseErrorFormatter(error))
+        }
+        HandledParseError(kind: ErrorKind) {
+            description("Parser error")
+            display("Parser error: {}", kind)
         }
         TemplateGenerationError(message: String) {
             description("Error generating template")

--- a/psqlpack/src/lib.rs
+++ b/psqlpack/src/lib.rs
@@ -33,8 +33,18 @@ pub mod ast {
 }
 pub use connection::ConnectionBuilder;
 pub use errors::{PsqlpackErrorKind, PsqlpackResult};
-pub use model::{Delta, GenerationOptions, Package, Project, PublishProfile, Toggle, template};
-pub use semver::{Semver, ServerVersion};
+pub use model::{
+    Capabilities,
+    Delta,
+    Dependency,
+    GenerationOptions,
+    Package,
+    Project,
+    PublishProfile,
+    Toggle,
+    template,
+};
+pub use semver::Semver;
 
 /// Allows usage of no logging, std `log`, or slog.
 pub enum LogConfig {

--- a/psqlpack/src/model/capabilities.rs
+++ b/psqlpack/src/model/capabilities.rs
@@ -1,0 +1,82 @@
+use std::str::FromStr;
+
+use semver::Semver;
+use connection::Connection;
+use errors::{PsqlpackResult, PsqlpackResultExt};
+use errors::PsqlpackErrorKind::*;
+
+use slog::Logger;
+use postgres::{Connection as PostgresConnection};
+use postgres::rows::Row;
+use postgres::types::{FromSql, Type, TEXT};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Extension {
+    pub name: String,
+    pub version: Semver,
+    pub installed: bool,
+}
+
+pub struct Capabilities {
+    pub server_version: Semver,
+    pub extensions: Vec<Extension>,
+}
+
+impl Capabilities {
+    pub fn from_connection(log: &Logger, connection: &Connection) -> PsqlpackResult<Capabilities> {
+        let log = log.new(o!("capabilities" => "from_connection"));
+
+        trace!(log, "Connecting to host");
+        let db_conn = connection.connect_host()?;
+
+        let version = Self::server_version(&db_conn)?;
+
+        let extensions = db_conn
+            .query(Q_EXTENSIONS, &[])
+            .chain_err(|| QueryExtensionsError)?;
+
+        dbtry!(db_conn.finish());
+
+        Ok(Capabilities {
+            server_version: version,
+            extensions: map!(extensions),
+        })
+    }
+
+    fn server_version(conn: &PostgresConnection) -> PsqlpackResult<Semver> {
+        let rows = conn.query("SHOW SERVER_VERSION;", &[])
+            .map_err(|e| DatabaseError(format!("Failed to retrieve server version: {}", e)))?;
+        let row = rows.iter().last();
+        if let Some(row) = row {
+            let version: Semver = row.get(0);
+            Ok(version)
+        } else {
+            bail!(DatabaseError("Failed to retrieve version from server".into()))
+        }
+    }
+}
+
+impl<'row> From<Row<'row>> for Extension {
+    fn from(row: Row) -> Self {
+        Extension {
+            name: row.get(0),
+            version: row.get(1),
+            installed: row.get(2),
+        }
+    }
+}
+
+impl FromSql for Semver {
+    // TODO: Better error handling
+    fn from_sql(_: &Type, raw: &[u8]) -> Result<Semver, Box<::std::error::Error + Sync + Send>> {
+        let version = String::from_utf8_lossy(raw);
+        Ok(Semver::from_str(&version).unwrap())
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        *ty == TEXT
+    }
+}
+
+static Q_EXTENSIONS: &'static str = "SELECT name, version, installed, requires
+                                     FROM pg_available_extension_versions ";

--- a/psqlpack/src/model/delta.rs
+++ b/psqlpack/src/model/delta.rs
@@ -326,7 +326,15 @@ impl<'a> Diffable<'a, Package> for LinkedColumn<'a> {
                 // target_set - src_set (e.g. adding new constraints)
                 for x in target_set.difference(&src_set) {
                     match *x {
-                        ColumnConstraint::Null | ColumnConstraint::NotNull => change_set.push(ChangeInstruction::ModifyColumnNull(self.table, &self.column)),
+                        ColumnConstraint::Null => {
+                            // This is a strange one - first check if the source specifies not null.
+                            // If it doesn't then it's likely implicitly implied to be null.
+                            // Also, we only check not null as if null is specified then we've got nothing to change!
+                            if self.column.constraints.iter().any(|c| ColumnConstraint::NotNull.eq(c)) {
+                                change_set.push(ChangeInstruction::ModifyColumnNull(self.table, &self.column));
+                            }
+                        },
+                        ColumnConstraint::NotNull => change_set.push(ChangeInstruction::ModifyColumnNull(self.table, &self.column)),
                         ColumnConstraint::Default(_) => change_set.push(ChangeInstruction::ModifyColumnDefault(self.table, &self.column)),
                         ColumnConstraint::Unique => change_set.push(ChangeInstruction::ModifyColumnUniqueConstraint(self.table, &self.column)),
                         ColumnConstraint::PrimaryKey => change_set.push(ChangeInstruction::ModifyColumnPrimaryKeyConstraint(self.table, &self.column)),
@@ -1396,6 +1404,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -1439,6 +1448,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -1473,6 +1483,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -1528,6 +1539,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -1583,6 +1595,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -1637,6 +1650,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_enum_values = Toggle::Allow;
@@ -1716,6 +1730,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -1749,6 +1764,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_enum_values = Toggle::Allow;
@@ -1832,6 +1848,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -1884,6 +1901,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -1951,6 +1969,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -2010,6 +2029,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_columns = Toggle::Allow;
@@ -2053,6 +2073,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -2114,6 +2135,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_primary_key_constraints = Toggle::Allow;
@@ -2164,6 +2186,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_primary_key_constraints = Toggle::Allow;
@@ -2240,6 +2263,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -2313,6 +2337,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_foreign_key_constraints = Toggle::Allow;
@@ -2375,6 +2400,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_foreign_key_constraints = Toggle::Allow;
@@ -2462,6 +2488,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
 
         let mut change_set = Vec::new();
@@ -2519,6 +2546,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_indexes = Toggle::Error;
@@ -2535,6 +2563,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_indexes = Toggle::Allow;
@@ -2612,6 +2641,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -2666,8 +2696,9 @@ mod tests {
                     name: "postgis".to_owned(),
                     version: Semver::new(2, 3, Some(7)),
                     installed: false,
-                }
+                },
             ],
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -2710,8 +2741,9 @@ mod tests {
                     name: "postgis".to_owned(),
                     version: Semver::new(2, 3, Some(7)),
                     installed: false,
-                }
+                },
             ],
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -2754,8 +2786,9 @@ mod tests {
                     name: "postgis".to_owned(),
                     version: Semver::new(2, 3, Some(7)),
                     installed: false,
-                }
+                },
             ],
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -2785,6 +2818,7 @@ mod tests {
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
             extensions: Vec::new(),
+            database_exists: true,
         };
         let publish_profile = PublishProfile::default();
 
@@ -2825,6 +2859,7 @@ mod tests {
                     installed: false,
                 },
             ],
+            database_exists: true,
         };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.upgrade_extensions = Toggle::Allow;
@@ -2869,8 +2904,9 @@ mod tests {
                     name: "postgis".to_owned(),
                     version: Semver::new(2, 3, Some(7)),
                     installed: true,
-                }
+                },
             ],
+            database_exists: true,
         };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.upgrade_extensions = Toggle::Allow;
@@ -2911,6 +2947,7 @@ mod tests {
                     installed: false,
                 }
             ],
+            database_exists: true,
         };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.upgrade_extensions = Toggle::Allow;
@@ -2961,6 +2998,7 @@ mod tests {
                     installed: false,
                 },
             ],
+            database_exists: true,
         };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.upgrade_extensions = Toggle::Ignore;
@@ -3001,6 +3039,7 @@ mod tests {
                     installed: false,
                 },
             ],
+            database_exists: true,
         };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.upgrade_extensions = Toggle::Error;

--- a/psqlpack/src/model/delta.rs
+++ b/psqlpack/src/model/delta.rs
@@ -8,16 +8,16 @@ use slog::Logger;
 use serde_json;
 
 use crate::Semver;
-use sql::ast::*;
 use connection::Connection;
-use model::{Node, Package, PublishProfile, Toggle};
 use errors::{PsqlpackResult, PsqlpackResultExt};
 use errors::PsqlpackErrorKind::*;
+use model::{Capabilities, Dependency, Node, Package, PublishProfile, Toggle};
+use sql::ast::*;
 
 enum DbObject<'a> {
     Column(&'a TableDefinition, &'a ColumnDefinition),
     Constraint(&'a TableDefinition, &'a TableConstraint),
-    Extension(&'a ExtensionDefinition), // 2
+    Extension(&'a Dependency),          // 2
     Function(&'a FunctionDefinition),   // 6 (ordered)
     Index(&'a IndexDefinition),         // 7
     Schema(&'a SchemaDefinition),       // 3
@@ -50,8 +50,9 @@ impl<'a> fmt::Display for DbObject<'a> {
 trait Diffable<'a, T> {
     fn generate(
         &self,
-        changeset: &mut Vec<ChangeInstruction<'a>>,
+        change_set: &mut Vec<ChangeInstruction<'a>>,
         target: &T,
+        target_capabilities: &Capabilities,
         publish_profile: &PublishProfile,
         log: &Logger,
     ) -> PsqlpackResult<()>;
@@ -60,54 +61,51 @@ trait Diffable<'a, T> {
 impl<'a> Diffable<'a, Package> for DbObject<'a> {
     fn generate(
         &self,
-        changeset: &mut Vec<ChangeInstruction<'a>>,
+        change_set: &mut Vec<ChangeInstruction<'a>>,
         target: &Package,
+        target_capabilities: &Capabilities,
         publish_profile: &PublishProfile,
         log: &Logger,
     ) -> PsqlpackResult<()> {
         match *self {
-            DbObject::Column(table, column) => LinkedColumn { table: &table, column: &column }.generate(changeset, target, publish_profile, log),
-            DbObject::Constraint(table, constraint) => LinkedTableConstraint { table: &table, constraint: &constraint }.generate(changeset, target, publish_profile, log),
-            DbObject::Extension(extension) => extension.generate(changeset, target, publish_profile, log),
-            DbObject::Function(function) => function.generate(changeset, target, publish_profile, log),
-            DbObject::Index(index) => index.generate(changeset, target, publish_profile, log),
-            DbObject::Schema(schema) => schema.generate(changeset, target, publish_profile, log),
-            DbObject::Script(script) => script.generate(changeset, target, publish_profile, log),
-            DbObject::Table(table) => table.generate(changeset, target, publish_profile, log),
-            DbObject::Type(ty) => ty.generate(changeset, target, publish_profile, log),
+            DbObject::Column(table, column) => LinkedColumn { table: &table, column: &column }.generate(change_set, target, target_capabilities, publish_profile, log),
+            DbObject::Constraint(table, constraint) => LinkedTableConstraint { table: &table, constraint: &constraint }.generate(change_set, target, target_capabilities, publish_profile, log),
+            DbObject::Extension(dependency) => ExtensionDefinition { name: &dependency.name, version: &dependency.version }.generate(change_set, target, target_capabilities, publish_profile, log),
+            DbObject::Function(function) => function.generate(change_set, target, target_capabilities, publish_profile, log),
+            DbObject::Index(index) => index.generate(change_set, target, target_capabilities, publish_profile, log),
+            DbObject::Schema(schema) => schema.generate(change_set, target, target_capabilities, publish_profile, log),
+            DbObject::Script(script) => script.generate(change_set, target, target_capabilities, publish_profile, log),
+            DbObject::Table(table) => table.generate(change_set, target, target_capabilities, publish_profile, log),
+            DbObject::Type(ty) => ty.generate(change_set, target, target_capabilities, publish_profile, log),
         }
     }
 }
 
-impl<'a> Diffable<'a, Package> for &'a ExtensionDefinition {
+struct ExtensionDefinition<'a> {
+    name: &'a String,
+    version: &'a Option<Semver>,
+}
+
+impl<'a> Diffable<'a, Package> for ExtensionDefinition<'a> {
     fn generate(
         &self,
-        changeset: &mut Vec<ChangeInstruction<'a>>,
-        target: &Package,
+        change_set: &mut Vec<ChangeInstruction<'a>>,
+        _target: &Package,
+        target_capabilities: &Capabilities,
         profile: &PublishProfile,
-        _: &Logger,
+        _log: &Logger,
     ) -> PsqlpackResult<()> {
-        // target, in this case, defines what is available as well as
-        // what is installed.
-        fn is_eq(a: &Option<Semver>, b: &Semver) -> bool {
-            if a.is_none() {
-                return false;
-            }
-            b.eq(a.as_ref().unwrap())
-        }
-
         let mut available =
-                    target.extensions
+                    target_capabilities.extensions
                         .iter()
-                        .filter(|e| e.name == self.name)
+                        .filter(|e| e.name.eq(self.name))
                         .collect::<Vec<_>>();
-        available.sort_by(|a, b| b.version.unwrap().cmp(&a.version.unwrap()));
+        available.sort_by(|a, b| b.version.cmp(&a.version));
 
         // First of all, check to see what is installed
         let installed = available
                         .iter()
-                        .filter(|e| e.installed.is_some() &&
-                                    e.installed.unwrap())
+                        .filter(|e| e.installed)
                         .count();
 
         // Nothing is installed
@@ -116,12 +114,12 @@ impl<'a> Diffable<'a, Package> for &'a ExtensionDefinition {
             let available_version = if let Some(ref version) = self.version {
                 available
                     .iter()
-                    .any(|e| is_eq(&e.version, version))
+                    .any(|e|e.version.eq( version))
             } else {
                 !available.is_empty()
             };
             if available_version {
-                changeset.push(ChangeInstruction::CreateExtension(self));
+                change_set.push(ChangeInstruction::CreateExtension(self.name.to_string(), *self.version));
             } else {
                 if let Some(ref version) = self.version {
                     bail!(PublishError(format!("Extension {} version {} not available to install", self.name, version)))
@@ -134,20 +132,20 @@ impl<'a> Diffable<'a, Package> for &'a ExtensionDefinition {
                 // A SPECIFIC version is specified so check to see if it is available
                 let version_available = available
                     .iter()
-                    .filter(|e| is_eq(&e.version, version))
+                    .filter(|e| e.version.eq(version))
                     .nth(0);
                 if let Some(v) = version_available {
                     // It's available so if it is not installed then upgrade
-                    if !v.installed.unwrap_or(false) {
+                    if !v.installed {
                         match profile.generation_options.upgrade_extensions {
                             Toggle::Allow => {
-                                changeset.push(ChangeInstruction::UpgradeExtension(self));
+                                change_set.push(ChangeInstruction::UpgradeExtension(self.name.to_string(), *self.version));
                             }
                             Toggle::Error => {
                                 bail!(PublishUnsafeOperationError(format!(
                                     "Extension {} version {} is available to upgrade",
                                     v.name,
-                                    v.version.unwrap(),
+                                    v.version,
                                 )));
                             }
                             Toggle::Ignore => {}
@@ -159,16 +157,16 @@ impl<'a> Diffable<'a, Package> for &'a ExtensionDefinition {
                 }
             } else {
                 // No version specified - are we on the latest?
-                if !available[0].installed.unwrap_or(false) {
+                if !available[0].installed {
                     match profile.generation_options.upgrade_extensions {
                         Toggle::Allow => {
-                            changeset.push(ChangeInstruction::UpgradeExtension(self));
+                            change_set.push(ChangeInstruction::UpgradeExtension(self.name.to_string(), *self.version));
                         }
                         Toggle::Error => {
                             bail!(PublishUnsafeOperationError(format!(
                                 "Extension {} version {} is available to upgrade",
                                 available[0].name,
-                                available[0].version.unwrap(),
+                                available[0].version,
                             )));
                         }
                         Toggle::Ignore => {}
@@ -183,15 +181,16 @@ impl<'a> Diffable<'a, Package> for &'a ExtensionDefinition {
 impl<'a> Diffable<'a, Package> for &'a FunctionDefinition {
     fn generate(
         &self,
-        changeset: &mut Vec<ChangeInstruction<'a>>,
-        _: &Package,
-        _: &PublishProfile,
-        _: &Logger,
+        change_set: &mut Vec<ChangeInstruction<'a>>,
+        _target: &Package,
+        _target_capabilities: &Capabilities,
+        _publish_profile: &PublishProfile,
+        _log: &Logger,
     ) -> PsqlpackResult<()> {
         // Since we don't really need to worry about this in PG we just
         // add it as is and rely on CREATE OR REPLACE. In the future, it'd
         // be good to check the hash or something to only do this when required
-        changeset.push(ChangeInstruction::ModifyFunction(self));
+        change_set.push(ChangeInstruction::ModifyFunction(self));
         Ok(())
     }
 }
@@ -199,15 +198,16 @@ impl<'a> Diffable<'a, Package> for &'a FunctionDefinition {
 impl<'a> Diffable<'a, Package> for &'a SchemaDefinition {
     fn generate(
         &self,
-        changeset: &mut Vec<ChangeInstruction<'a>>,
+        change_set: &mut Vec<ChangeInstruction<'a>>,
         target: &Package,
-        _: &PublishProfile,
-        _: &Logger,
+        _target_capabilities: &Capabilities,
+        _publish_profile: &PublishProfile,
+        _log: &Logger,
     ) -> PsqlpackResult<()> {
         // Only add schema's, we do not drop them at this point
         let schema_exists = target.schemas.iter().any(|s| s.name == self.name);
         if !schema_exists {
-            changeset.push(ChangeInstruction::AddSchema(self));
+            change_set.push(ChangeInstruction::AddSchema(self));
         }
         Ok(())
     }
@@ -216,12 +216,13 @@ impl<'a> Diffable<'a, Package> for &'a SchemaDefinition {
 impl<'a> Diffable<'a, Package> for &'a ScriptDefinition {
     fn generate(
         &self,
-        changeset: &mut Vec<ChangeInstruction<'a>>,
-        _: &Package,
-        _: &PublishProfile,
-        _: &Logger,
+        change_set: &mut Vec<ChangeInstruction<'a>>,
+        _target: &Package,
+        _target_capabilities: &Capabilities,
+        _publish_profile: &PublishProfile,
+        _log: &Logger,
     ) -> PsqlpackResult<()> {
-        changeset.push(ChangeInstruction::RunScript(self));
+        change_set.push(ChangeInstruction::RunScript(self));
         Ok(())
     }
 }
@@ -229,8 +230,9 @@ impl<'a> Diffable<'a, Package> for &'a ScriptDefinition {
 impl<'a> Diffable<'a, Package> for &'a TableDefinition {
     fn generate(
         &self,
-        changeset: &mut Vec<ChangeInstruction<'a>>,
+        change_set: &mut Vec<ChangeInstruction<'a>>,
         target: &Package,
+        _target_capabilities: &Capabilities,
         publish_profile: &PublishProfile,
         _log: &Logger,
     ) -> PsqlpackResult<()> {
@@ -241,7 +243,7 @@ impl<'a> Diffable<'a, Package> for &'a TableDefinition {
                 if !self.columns.iter().any(|src| tgt.name.eq(&src.name)) {
                     // Column in target but not in source
                     match publish_profile.generation_options.drop_columns {
-                        Toggle::Allow => changeset.push(ChangeInstruction::DropColumn(self, tgt.name.to_owned())),
+                        Toggle::Allow => change_set.push(ChangeInstruction::DropColumn(self, tgt.name.to_owned())),
                         Toggle::Error => {
                             bail!(PublishUnsafeOperationError(format!(
                                 "Unable to drop column as dropping columns is currently disabled: {}",
@@ -279,12 +281,12 @@ impl<'a> Diffable<'a, Package> for &'a TableDefinition {
                         }
                     };
                     if remove_ok {
-                        changeset.push(ChangeInstruction::DropConstraint(self, tgt.name().to_owned()));
+                        change_set.push(ChangeInstruction::DropConstraint(self, tgt.name().to_owned()));
                     }
                 }
             }
         } else {
-            changeset.push(ChangeInstruction::AddTable(self));
+            change_set.push(ChangeInstruction::AddTable(self));
         }
         Ok(())
     }
@@ -298,8 +300,9 @@ struct LinkedColumn<'a> {
 impl<'a> Diffable<'a, Package> for LinkedColumn<'a> {
     fn generate(
         &self,
-        changeset: &mut Vec<ChangeInstruction<'a>>,
+        change_set: &mut Vec<ChangeInstruction<'a>>,
         target: &Package,
+        _target_capabilities: &Capabilities,
         _publish_profile: &PublishProfile,
         _log: &Logger,
     ) -> PsqlpackResult<()> {
@@ -313,7 +316,7 @@ impl<'a> Diffable<'a, Package> for LinkedColumn<'a> {
             if let Some(target_column) = target_column {
                 // Check the type
                 if !self.column.sql_type.eq(&target_column.sql_type) {
-                    changeset.push(ChangeInstruction::ModifyColumnType(self.table, &self.column));
+                    change_set.push(ChangeInstruction::ModifyColumnType(self.table, &self.column));
                 }
 
                 // Check column constraints
@@ -323,10 +326,10 @@ impl<'a> Diffable<'a, Package> for LinkedColumn<'a> {
                 // target_set - src_set (e.g. adding new constraints)
                 for x in target_set.difference(&src_set) {
                     match *x {
-                        ColumnConstraint::Null | ColumnConstraint::NotNull => changeset.push(ChangeInstruction::ModifyColumnNull(self.table, &self.column)),
-                        ColumnConstraint::Default(_) => changeset.push(ChangeInstruction::ModifyColumnDefault(self.table, &self.column)),
-                        ColumnConstraint::Unique => changeset.push(ChangeInstruction::ModifyColumnUniqueConstraint(self.table, &self.column)),
-                        ColumnConstraint::PrimaryKey => changeset.push(ChangeInstruction::ModifyColumnPrimaryKeyConstraint(self.table, &self.column)),
+                        ColumnConstraint::Null | ColumnConstraint::NotNull => change_set.push(ChangeInstruction::ModifyColumnNull(self.table, &self.column)),
+                        ColumnConstraint::Default(_) => change_set.push(ChangeInstruction::ModifyColumnDefault(self.table, &self.column)),
+                        ColumnConstraint::Unique => change_set.push(ChangeInstruction::ModifyColumnUniqueConstraint(self.table, &self.column)),
+                        ColumnConstraint::PrimaryKey => change_set.push(ChangeInstruction::ModifyColumnPrimaryKeyConstraint(self.table, &self.column)),
                     }
                 }
 
@@ -334,7 +337,7 @@ impl<'a> Diffable<'a, Package> for LinkedColumn<'a> {
 
             } else {
                 // Doesn't exist, add it
-                changeset.push(ChangeInstruction::AddColumn(self.table, &self.column));
+                change_set.push(ChangeInstruction::AddColumn(self.table, &self.column));
             }
         }
         Ok(())
@@ -349,8 +352,9 @@ struct LinkedTableConstraint<'a> {
 impl<'a> Diffable<'a, Package> for LinkedTableConstraint<'a> {
     fn generate(
         &self,
-        changeset: &mut Vec<ChangeInstruction<'a>>,
+        change_set: &mut Vec<ChangeInstruction<'a>>,
         target: &Package,
+        _target_capabilities: &Capabilities,
         publish_profile: &PublishProfile,
         _log: &Logger,
     ) -> PsqlpackResult<()> {
@@ -454,17 +458,17 @@ impl<'a> Diffable<'a, Package> for LinkedTableConstraint<'a> {
                         }
                     };
                     if remove_ok {
-                        changeset.push(ChangeInstruction::DropConstraint(self.table, self.constraint.name().to_owned()));
-                        changeset.push(ChangeInstruction::AddConstraint(self.table, self.constraint));
+                        change_set.push(ChangeInstruction::DropConstraint(self.table, self.constraint.name().to_owned()));
+                        change_set.push(ChangeInstruction::AddConstraint(self.table, self.constraint));
                     }
                 }
             } else {
                 // Doesn't exist, add it
-                changeset.push(ChangeInstruction::AddConstraint(self.table, &self.constraint));
+                change_set.push(ChangeInstruction::AddConstraint(self.table, &self.constraint));
             }
 
         } else {
-            changeset.push(ChangeInstruction::AddConstraint(self.table, &self.constraint));
+            change_set.push(ChangeInstruction::AddConstraint(self.table, &self.constraint));
         }
         Ok(())
     }
@@ -473,8 +477,9 @@ impl<'a> Diffable<'a, Package> for LinkedTableConstraint<'a> {
 impl<'a> Diffable<'a, Package> for &'a IndexDefinition {
     fn generate(
         &self,
-        changeset: &mut Vec<ChangeInstruction<'a>>,
+        change_set: &mut Vec<ChangeInstruction<'a>>,
         target: &Package,
+        _target_capabilities: &Capabilities,
         publish_profile: &PublishProfile,
         _log: &Logger,
     ) -> PsqlpackResult<()> {
@@ -484,11 +489,11 @@ impl<'a> Diffable<'a, Package> for &'a IndexDefinition {
         if let Some(index) = index {
             // We should be able to just use an eq for this since column ordering is significant
             if index.ne(self) {
-                changeset.push(ChangeInstruction::DropIndex(self.fully_qualified_name(), concurrently));
-                changeset.push(ChangeInstruction::AddIndex(self, concurrently));
+                change_set.push(ChangeInstruction::DropIndex(self.fully_qualified_name(), concurrently));
+                change_set.push(ChangeInstruction::AddIndex(self, concurrently));
             }
         } else {
-            changeset.push(ChangeInstruction::AddIndex(self, concurrently));
+            change_set.push(ChangeInstruction::AddIndex(self, concurrently));
         }
         Ok(())
     }
@@ -497,16 +502,17 @@ impl<'a> Diffable<'a, Package> for &'a IndexDefinition {
 impl<'a> Diffable<'a, Package> for &'a TypeDefinition {
     fn generate(
         &self,
-        changeset: &mut Vec<ChangeInstruction<'a>>,
+        change_set: &mut Vec<ChangeInstruction<'a>>,
         target: &Package,
+        _target_capabilities: &Capabilities,
         publish_profile: &PublishProfile,
         log: &Logger,
     ) -> PsqlpackResult<()> {
         let ty = target.types.iter().find(|t| t.name == self.name);
         if let Some(ty) = ty {
-            self.generate(changeset, ty, publish_profile, log)
+            self.generate(change_set, ty, _target_capabilities, publish_profile, log)
         } else {
-            changeset.push(ChangeInstruction::AddType(self));
+            change_set.push(ChangeInstruction::AddType(self));
             Ok(())
         }
     }
@@ -515,10 +521,11 @@ impl<'a> Diffable<'a, Package> for &'a TypeDefinition {
 impl<'a> Diffable<'a, TypeDefinition> for &'a TypeDefinition {
     fn generate(
         &self,
-        changeset: &mut Vec<ChangeInstruction<'a>>,
+        change_set: &mut Vec<ChangeInstruction<'a>>,
         target: &TypeDefinition,
+        _target_capabilities: &Capabilities,
         publish_profile: &PublishProfile,
-        _: &Logger,
+        _log: &Logger,
     ) -> PsqlpackResult<()> {
         if self.name.ne(&target.name) {
             bail!(PublishInvalidOperationError(format!(
@@ -545,7 +552,7 @@ impl<'a> Diffable<'a, TypeDefinition> for &'a TypeDefinition {
                         if !to_delete.is_empty() {
                             match publish_profile.generation_options.drop_enum_values {
                                 Toggle::Allow => {
-                                    changeset.extend(
+                                    change_set.extend(
                                         to_delete
                                             .drain(..)
                                             .map(|d| ChangeInstruction::ModifyType(self, d)),
@@ -572,7 +579,7 @@ impl<'a> Diffable<'a, TypeDefinition> for &'a TypeDefinition {
                         for value in source_values {
                             if !working.contains(&value) {
                                 if index == 0 {
-                                    changeset.push(ChangeInstruction::ModifyType(
+                                    change_set.push(ChangeInstruction::ModifyType(
                                         self,
                                         TypeModificationAction::AddEnumValueBefore {
                                             value: value.to_owned(),
@@ -581,7 +588,7 @@ impl<'a> Diffable<'a, TypeDefinition> for &'a TypeDefinition {
                                     ));
                                     working.insert(0, value);
                                 } else {
-                                    changeset.push(ChangeInstruction::ModifyType(
+                                    change_set.push(ChangeInstruction::ModifyType(
                                         self,
                                         TypeModificationAction::AddEnumValueAfter {
                                             value: value.to_owned(),
@@ -610,17 +617,18 @@ impl<'package> Delta<'package> {
         package: &'package Package,
         target: Option<Package>,
         target_database_name: String,
+        target_capabilities: Capabilities,
         publish_profile: PublishProfile,
     ) -> PsqlpackResult<Delta<'package>> {
         let log = log.new(o!("delta" => "generate"));
 
-        // Start the changeset
-        let mut changeset = Vec::new();
+        // Start the change_set
+        let mut change_set = Vec::new();
 
         // If we always recreate then add a drop and set to false
         let mut target = target;
         if target.is_some() && publish_profile.generation_options.always_recreate_database {
-            changeset.push(ChangeInstruction::DropDatabase(
+            change_set.push(ChangeInstruction::DropDatabase(
                 target_database_name.to_owned(),
             ));
             target = None;
@@ -630,7 +638,7 @@ impl<'package> Delta<'package> {
         let target_package = match target {
             Some(target_package) => target_package,
             None => {
-                changeset.push(ChangeInstruction::CreateDatabase(
+                change_set.push(ChangeInstruction::CreateDatabase(
                     target_database_name.to_owned(),
                 ));
                 Package::new()
@@ -638,7 +646,7 @@ impl<'package> Delta<'package> {
         };
 
         // Set the connection instruction
-        changeset.push(ChangeInstruction::UseDatabase(
+        change_set.push(ChangeInstruction::UseDatabase(
             target_database_name.to_owned(),
         ));
 
@@ -671,7 +679,7 @@ impl<'package> Delta<'package> {
         for index in &target_package.indexes {
             if !package.indexes.iter().any(|idx| idx.is_same_index(&index)) {
                 match publish_profile.generation_options.drop_indexes {
-                    Toggle::Allow => changeset.push(ChangeInstruction::DropIndex(index.fully_qualified_name(), publish_profile.generation_options.force_concurrent_indexes)),
+                    Toggle::Allow => change_set.push(ChangeInstruction::DropIndex(index.fully_qualified_name(), publish_profile.generation_options.force_concurrent_indexes)),
                     Toggle::Error => bail!(
                                         PublishUnsafeOperationError(
                                             format!("Attempted to drop index {} however dropping indexes is currently disabled", index.name)
@@ -686,7 +694,7 @@ impl<'package> Delta<'package> {
         for function in &target_package.functions {
             if !package.functions.iter().any(|t| t.name.eq(&function.name)) {
                 match publish_profile.generation_options.drop_functions {
-                    Toggle::Allow => changeset.push(ChangeInstruction::DropFunction(function.name.to_string())),
+                    Toggle::Allow => change_set.push(ChangeInstruction::DropFunction(function.name.to_string())),
                     Toggle::Error => bail!(
                                         PublishUnsafeOperationError(
                                             format!("Attempted to drop function {} however dropping functions is currently disabled", function.name)
@@ -701,7 +709,7 @@ impl<'package> Delta<'package> {
         for table in &target_package.tables {
             if !package.tables.iter().any(|t| t.name.eq(&table.name)) {
                 match publish_profile.generation_options.drop_tables {
-                    Toggle::Allow => changeset.push(ChangeInstruction::DropTable(table.name.to_string())),
+                    Toggle::Allow => change_set.push(ChangeInstruction::DropTable(table.name.to_string())),
                     Toggle::Error => bail!(
                                         PublishUnsafeOperationError(
                                             format!("Attempted to drop table {} however dropping tables is currently disabled", table.name)
@@ -748,21 +756,21 @@ impl<'package> Delta<'package> {
 
         // Go through each item in order and figure out what to do with it
         for item in &build_order {
-            item.generate(&mut changeset, &target_package, &publish_profile, &log)?;
+            item.generate(&mut change_set, &target_package, &target_capabilities, &publish_profile, &log)?;
         }
 
-        Ok(Delta(changeset))
+        Ok(Delta(change_set))
     }
 
     pub fn apply(&self, log: &Logger, connection: &Connection) -> PsqlpackResult<()> {
         let log = log.new(o!("delta" => "apply"));
 
-        let changeset = &self.0;
+        let change_set = &self.0;
 
         // These instructions turn into SQL statements that get executed
         let mut conn = connection.connect_host()?;
 
-        for change in changeset.iter() {
+        for change in change_set.iter() {
             if let ChangeInstruction::UseDatabase(..) = *change {
                 conn.finish().chain_err(|| DatabaseConnectionFinishError)?;
                 conn = connection.connect_database()?;
@@ -783,12 +791,12 @@ impl<'package> Delta<'package> {
     }
 
     pub fn write_report(&self, destination: &Path) -> PsqlpackResult<()> {
-        let changeset = &self.0;
+        let change_set = &self.0;
 
         File::create(destination)
             .chain_err(|| GenerationError("Failed to generate report".to_owned()))
             .and_then(|writer| {
-                serde_json::to_writer_pretty(writer, &changeset)
+                serde_json::to_writer_pretty(writer, &change_set)
                     .chain_err(|| GenerationError("Failed to generate report".to_owned()))
             })?;
 
@@ -796,7 +804,7 @@ impl<'package> Delta<'package> {
     }
 
     pub fn write_sql(&self, log: &Logger, destination: &Path) -> PsqlpackResult<()> {
-        let changeset = &self.0;
+        let change_set = &self.0;
 
         // These instructions turn into a single SQL file
         let mut out = match File::create(destination) {
@@ -806,7 +814,7 @@ impl<'package> Delta<'package> {
             )),
         };
 
-        for change in changeset.iter() {
+        for change in change_set.iter() {
             let sql = change.to_sql(log);
             match out.write_all(sql.as_bytes()) {
                 Ok(_) => {
@@ -837,8 +845,8 @@ pub enum ChangeInstruction<'input> {
     UseDatabase(String),
 
     // Extensions - no delete for now
-    CreateExtension(&'input ExtensionDefinition),
-    UpgradeExtension(&'input ExtensionDefinition),
+    CreateExtension(String, Option<Semver>),
+    UpgradeExtension(String, Option<Semver>),
 
     // Schema
     AddSchema(&'input SchemaDefinition),
@@ -898,18 +906,18 @@ impl<'input> fmt::Display for ChangeInstruction<'input> {
             UseDatabase(ref database) => write!(f, "Use database: {}", database),
 
             // Extensions
-            CreateExtension(extension) => {
-                if let Some(ref version) = extension.version {
-                    write!(f, "Create extension: {} version {}", extension.name, version)
+            CreateExtension(ref name, ref version) => {
+                if let Some(ref version) = version {
+                    write!(f, "Create extension: {} version {}", name, version)
                 } else {
-                    write!(f, "Create extension: {}", extension.name)
+                    write!(f, "Create extension: {}", name)
                 }
             },
-            UpgradeExtension(extension) => {
-                if let Some(ref version) = extension.version {
-                    write!(f, "Upgrade extension: {} version {}", extension.name, version)
+            UpgradeExtension(ref name, ref version) => {
+                if let Some(ref version) = version {
+                    write!(f, "Upgrade extension: {} version {}", name, version)
                 } else {
-                    write!(f, "Upgrade extension: {}", extension.name)
+                    write!(f, "Upgrade extension: {}", name)
                 }
             },
 
@@ -990,18 +998,18 @@ impl<'input> ChangeInstruction<'input> {
             ChangeInstruction::UseDatabase(ref db) => format!("-- Using database `{}`", db),
 
             // Extension level
-            ChangeInstruction::CreateExtension(ext) => {
-                if let Some(ref version) = ext.version {
-                    format!("CREATE EXTENSION {} WITH VERSION \"{}\"", ext.name, version)
+            ChangeInstruction::CreateExtension(ref name, ref version) => {
+                if let Some(ref version) = version {
+                    format!("CREATE EXTENSION {} WITH VERSION \"{}\"", name, version)
                 } else {
-                    format!("CREATE EXTENSION {}", ext.name)
+                    format!("CREATE EXTENSION {}", name)
                 }
             },
-            ChangeInstruction::UpgradeExtension(ext) => {
-                if let Some(ref version) = ext.version {
-                    format!("ALTER EXTENSION {} UPDATE TO \"{}\"", ext.name, version)
+            ChangeInstruction::UpgradeExtension(ref name, ref version) => {
+                if let Some(ref version) = version {
+                    format!("ALTER EXTENSION {} UPDATE TO \"{}\"", name, version)
                 } else {
-                    format!("ALTER EXTENSION {} UPDATE", ext.name)
+                    format!("ALTER EXTENSION {} UPDATE", name)
                 }
             },
 
@@ -1385,15 +1393,23 @@ mod tests {
 
         // Create an empty package (i.e. so it needs to create the type)
         let existing_database = Package::new();
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
-        let result = (&source_type).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&source_type).generate(&mut change_set,
+                                             &existing_database,
+                                             &capabilities,
+                                             &publish_profile,
+                                             &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to add
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
             ChangeInstruction::AddType(ref ty) => {
                 assert_that!(ty.name).is_equal_to("colors".to_owned());
                 let values = match ty.kind {
@@ -1408,7 +1424,7 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("CREATE TYPE colors AS ENUM (\n  'red',\n  'green',\n  'blue'\n)".to_owned());
     }
 
@@ -1420,14 +1436,22 @@ mod tests {
         // Create a package with the type already defined (same as base type)
         let mut existing_database = Package::new();
         existing_database.types.push(base_type());
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
-        let result = (&source_type).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&source_type).generate(&mut change_set,
+                                             &existing_database,
+                                             &capabilities,
+                                             &publish_profile,
+                                             &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to add
-        assert_that!(changeset).is_empty();
+        assert_that!(change_set).is_empty();
     }
 
     #[test]
@@ -1446,15 +1470,23 @@ mod tests {
         // Create a package with the type already defined
         let mut existing_database = Package::new();
         existing_database.types.push(base_type());
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
-        let result = (&source_type).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&source_type).generate(&mut change_set,
+                                             &existing_database,
+                                             &capabilities,
+                                             &publish_profile,
+                                             &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to modify the enum with an additional value
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
             ChangeInstruction::ModifyType(ty, ref action) => {
                 assert_that!(ty.name).is_equal_to("colors".to_owned());
 
@@ -1474,7 +1506,7 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log)).is_equal_to("ALTER TYPE colors ADD VALUE 'black' AFTER 'blue'".to_owned());
+        assert_that!(change_set[0].to_sql(&log)).is_equal_to("ALTER TYPE colors ADD VALUE 'black' AFTER 'blue'".to_owned());
     }
 
     #[test]
@@ -1493,15 +1525,23 @@ mod tests {
         // Create a package with the type already defined
         let mut existing_database = Package::new();
         existing_database.types.push(base_type());
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
-        let result = (&source_type).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&source_type).generate(&mut change_set,
+                                             &existing_database,
+                                             &capabilities,
+                                             &publish_profile,
+                                             &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to modify the enum with an additional value
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
             ChangeInstruction::ModifyType(ty, ref action) => {
                 assert_that!(ty.name).is_equal_to("colors".to_owned());
 
@@ -1521,7 +1561,7 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log)).is_equal_to("ALTER TYPE colors ADD VALUE 'black' BEFORE 'red'".to_owned());
+        assert_that!(change_set[0].to_sql(&log)).is_equal_to("ALTER TYPE colors ADD VALUE 'black' BEFORE 'red'".to_owned());
     }
 
     #[test]
@@ -1540,15 +1580,23 @@ mod tests {
         // Create a package with the type already defined
         let mut existing_database = Package::new();
         existing_database.types.push(base_type());
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
-        let result = (&source_type).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&source_type).generate(&mut change_set,
+                                             &existing_database,
+                                             &capabilities,
+                                             &publish_profile,
+                                             &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to modify the enum with an additional value
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
             ChangeInstruction::ModifyType(ty, ref action) => {
                 assert_that!(ty.name).is_equal_to("colors".to_owned());
 
@@ -1568,7 +1616,7 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log)).is_equal_to("ALTER TYPE colors ADD VALUE 'black' AFTER 'green'".to_owned());
+        assert_that!(change_set[0].to_sql(&log)).is_equal_to("ALTER TYPE colors ADD VALUE 'black' AFTER 'green'".to_owned());
     }
 
     #[test]
@@ -1586,18 +1634,26 @@ mod tests {
         // Create a package with the type already defined
         let mut existing_database = Package::new();
         existing_database.types.push(base_type());
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_enum_values = Toggle::Allow;
 
-        let mut changeset = Vec::new();
-        let result = (&source_type).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&source_type).generate(&mut change_set,
+                                             &existing_database,
+                                             &capabilities,
+                                             &publish_profile,
+                                             &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to modify the enum with an additional value
-        assert_that!(changeset).has_length(2);
+        assert_that!(change_set).has_length(2);
 
         // Removals first
-        match changeset[0] {
+        match change_set[0] {
             ChangeInstruction::ModifyType(ty, ref action) => {
                 assert_that!(ty.name).is_equal_to("colors".to_owned());
 
@@ -1612,7 +1668,7 @@ mod tests {
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log)).is_equal_to(
+        assert_that!(change_set[0].to_sql(&log)).is_equal_to(
             "DELETE FROM pg_enum \
              WHERE enumlabel = 'red' AND \
              enumtypid = (SELECT oid FROM pg_type WHERE typname = 'colors')"
@@ -1620,7 +1676,7 @@ mod tests {
         );
 
         // Additions second
-        match changeset[1] {
+        match change_set[1] {
             ChangeInstruction::ModifyType(ty, ref action) => {
                 assert_that!(ty.name).is_equal_to("colors".to_owned());
 
@@ -1639,7 +1695,7 @@ mod tests {
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
         // Check the SQL generation
-        assert_that!(changeset[1].to_sql(&log)).is_equal_to("ALTER TYPE colors ADD VALUE 'black' BEFORE 'green'".to_owned());
+        assert_that!(change_set[1].to_sql(&log)).is_equal_to("ALTER TYPE colors ADD VALUE 'black' BEFORE 'green'".to_owned());
     }
 
     #[test]
@@ -1657,10 +1713,18 @@ mod tests {
         // Create a package with the type already defined
         let mut existing_database = Package::new();
         existing_database.types.push(base_type());
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
-        let result = (&source_type).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&source_type).generate(&mut change_set,
+                                             &existing_database,
+                                             &capabilities,
+                                             &publish_profile,
+                                             &log);
         assert_that!(result).is_err();
         match result.err().unwrap() {
             PsqlpackError(PublishUnsafeOperationError(_), _) => {}
@@ -1682,18 +1746,26 @@ mod tests {
         // Create a package with the type already defined
         let mut existing_database = Package::new();
         existing_database.types.push(base_type());
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_enum_values = Toggle::Allow;
 
-        let mut changeset = Vec::new();
-        let result = (&source_type).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&source_type).generate(&mut change_set,
+                                             &existing_database,
+                                             &capabilities,
+                                             &publish_profile,
+                                             &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to modify the enum with an additional value
-        assert_that!(changeset).has_length(1);
+        assert_that!(change_set).has_length(1);
 
         // Removals first
-        match changeset[0] {
+        match change_set[0] {
             ChangeInstruction::ModifyType(ty, ref action) => {
                 assert_that!(ty.name).is_equal_to("colors".to_owned());
 
@@ -1708,7 +1780,7 @@ mod tests {
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log)).is_equal_to(
+        assert_that!(change_set[0].to_sql(&log)).is_equal_to(
             "DELETE FROM pg_enum \
              WHERE enumlabel = 'red' AND \
              enumtypid = (SELECT oid FROM pg_type WHERE typname = 'colors')"
@@ -1757,15 +1829,23 @@ mod tests {
 
         // Create an empty database
         let existing_database = Package::new();
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
-        let result = (&source_table).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&source_table).generate(&mut change_set,
+                                              &existing_database,
+                                              &capabilities,
+                                              &publish_profile,
+                                              &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to create a new table
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
             ChangeInstruction::AddTable(ref table) => {
                 assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
                 assert_that!(table.columns).has_length(3);
@@ -1778,7 +1858,7 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("CREATE TABLE my.contacts (\n\
                 \tid serial NOT NULL PRIMARY KEY,\n\
                 \tcompany_id bigint NOT NULL,\n\
@@ -1801,21 +1881,33 @@ mod tests {
         // Create a database with the base table already defined.
         let mut existing_database = Package::new();
         existing_database.tables.push(base_table());
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
+        let mut change_set = Vec::new();
         // First, check that source table changes do nothing
-        let _ = (&source_table).generate(&mut changeset, &existing_database, &publish_profile, &log);
-        assert_that!(changeset).is_empty();
+        let _ = (&source_table).generate(&mut change_set,
+                                         &existing_database,
+                                         &capabilities,
+                                         &publish_profile,
+                                         &log);
+        assert_that!(change_set).is_empty();
 
         // Now we check with a linked column
         let result = LinkedColumn { table: &source_table, column: &source_table.columns.last().unwrap()}
-                        .generate(&mut changeset, &existing_database, &publish_profile, &log);
+                        .generate(&mut change_set,
+                                  &existing_database,
+                                  &capabilities,
+                                  &publish_profile,
+                                  &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to create a new table
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
             ChangeInstruction::AddColumn(ref table, ref column) => {
                 assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
                 assert_that!(column.name).is_equal_to("last_name".to_owned());
@@ -1826,7 +1918,7 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("ALTER TABLE my.contacts ADD COLUMN last_name varchar(100) NOT NULL".to_owned());
     }
 
@@ -1856,21 +1948,33 @@ mod tests {
             });
 
         existing_database.tables.push(existing_table);
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
+        let mut change_set = Vec::new();
         // First, check that source table changes do nothing
-        let _ = (&source_table).generate(&mut changeset, &existing_database, &publish_profile, &log);
-        assert_that!(changeset).is_empty();
+        let _ = (&source_table).generate(&mut change_set,
+                                         &existing_database,
+                                         &capabilities,
+                                         &publish_profile,
+                                         &log);
+        assert_that!(change_set).is_empty();
 
         // Now we check with a linked column
         let result = LinkedColumn { table: &source_table, column: &source_table.columns.last().unwrap()}
-                        .generate(&mut changeset, &existing_database, &publish_profile, &log);
+                        .generate(&mut change_set,
+                                  &existing_database,
+                                  &capabilities,
+                                  &publish_profile,
+                                  &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to create a new table
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
             ChangeInstruction::ModifyColumnType(ref table, ref column) => {
                 assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
                 assert_that!(column.name).is_equal_to("last_name".to_owned());
@@ -1881,7 +1985,7 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("ALTER TABLE my.contacts ALTER COLUMN last_name TYPE varchar(200)".to_owned());
     }
 
@@ -1903,16 +2007,24 @@ mod tests {
             });
 
         existing_database.tables.push(existing_table);
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_columns = Toggle::Allow;
 
-        let mut changeset = Vec::new();
-        let result = (&source_table).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&source_table).generate(&mut change_set,
+                                              &existing_database,
+                                              &capabilities,
+                                              &publish_profile,
+                                              &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to create a new table
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
             ChangeInstruction::DropColumn(ref table, ref column_name) => {
                 assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
                 assert_that!(*column_name).is_equal_to("last_name".to_owned());
@@ -1921,7 +2033,7 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("ALTER TABLE my.contacts DROP COLUMN last_name".to_owned());
     }
 
@@ -1938,21 +2050,33 @@ mod tests {
         // Create a database with the base table already defined.
         let mut existing_database = Package::new();
         existing_database.tables.push(base_table());
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
+        let mut change_set = Vec::new();
         // First, check that source table changes do nothing
-        let _ = (&source_table).generate(&mut changeset, &existing_database, &publish_profile, &log);
-        assert_that!(changeset).is_empty();
+        let _ = (&source_table).generate(&mut change_set,
+                                         &existing_database,
+                                         &capabilities,
+                                         &publish_profile,
+                                         &log);
+        assert_that!(change_set).is_empty();
 
         // Now we check with a linked table constraint
         let result = LinkedTableConstraint { table: &source_table, constraint: &source_table.constraints.first().unwrap()}
-                        .generate(&mut changeset, &existing_database, &publish_profile, &log);
+                        .generate(&mut change_set,
+                                  &existing_database,
+                                  &capabilities,
+                                  &publish_profile,
+                                  &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to add a constraint
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
             ChangeInstruction::AddConstraint(ref table, ref constraint) => {
                 assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
                 match *constraint {
@@ -1969,7 +2093,7 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("ALTER TABLE my.contacts\nADD CONSTRAINT pk_my_contacts_id PRIMARY KEY (id) WITH (FILLFACTOR=80)".to_owned());
     }
 
@@ -1987,17 +2111,25 @@ mod tests {
             parameters: Some(vec![IndexParameter::FillFactor(80)]),
         });
         existing_database.tables.push(existing_table);
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_primary_key_constraints = Toggle::Allow;
 
-        let mut changeset = Vec::new();
-        // This changeset gets generated at the table level
-        let result = (&source_table).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        // This change_set gets generated at the table level
+        let result = (&source_table).generate(&mut change_set,
+                                              &existing_database,
+                                              &capabilities,
+                                              &publish_profile,
+                                              &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to remove the constraint
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
             ChangeInstruction::DropConstraint(ref table, ref name) => {
                 assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
                 assert_that!(*name).is_equal_to("pk_my_contacts_id".to_owned());
@@ -2006,7 +2138,7 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("ALTER TABLE my.contacts\nDROP CONSTRAINT pk_my_contacts_id".to_owned());
     }
 
@@ -2029,29 +2161,41 @@ mod tests {
                 parameters: Some(vec![IndexParameter::FillFactor(80)]),
             });
         existing_database.tables.push(existing_table);
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_primary_key_constraints = Toggle::Allow;
 
-        let mut changeset = Vec::new();
+        let mut change_set = Vec::new();
         // First, check that source table changes do nothing
-        let _ = (&source_table).generate(&mut changeset, &existing_database, &publish_profile, &log);
-        assert_that!(changeset).is_empty();
+        let _ = (&source_table).generate(&mut change_set,
+                                         &existing_database,
+                                         &capabilities,
+                                         &publish_profile,
+                                         &log);
+        assert_that!(change_set).is_empty();
 
         // Now we check with a linked table constraint
         let result = LinkedTableConstraint { table: &source_table, constraint: &source_table.constraints.first().unwrap()}
-                        .generate(&mut changeset, &existing_database, &publish_profile, &log);
+                        .generate(&mut change_set,
+                                  &existing_database,
+                                  &capabilities,
+                                  &publish_profile,
+                                  &log);
         assert_that!(result).is_ok();
 
         // Primary keys cannot be altered, so we drop/create
-        assert_that!(changeset).has_length(2);
-        match changeset[0] {
+        assert_that!(change_set).has_length(2);
+        match change_set[0] {
             ChangeInstruction::DropConstraint(ref table, ref name) => {
                 assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
                 assert_that!(*name).is_equal_to("pk_my_contacts_id".to_owned());
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
-        match changeset[1] {
+        match change_set[1] {
             ChangeInstruction::AddConstraint(ref table, ref constraint) => {
                 assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
                 match *constraint {
@@ -2068,9 +2212,9 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("ALTER TABLE my.contacts\nDROP CONSTRAINT pk_my_contacts_id".to_owned());
-        assert_that!(changeset[1].to_sql(&log))
+        assert_that!(change_set[1].to_sql(&log))
             .is_equal_to("ALTER TABLE my.contacts\nADD CONSTRAINT pk_my_contacts_id PRIMARY KEY (id) WITH (FILLFACTOR=80)".to_owned());
     }
 
@@ -2093,21 +2237,33 @@ mod tests {
         // Create a database with the base table already defined.
         let mut existing_database = Package::new();
         existing_database.tables.push(base_table());
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
+        let mut change_set = Vec::new();
         // First, check that source table changes do nothing
-        let _ = (&source_table).generate(&mut changeset, &existing_database, &publish_profile, &log);
-        assert_that!(changeset).is_empty();
+        let _ = (&source_table).generate(&mut change_set,
+                                         &existing_database,
+                                         &capabilities,
+                                         &publish_profile,
+                                         &log);
+        assert_that!(change_set).is_empty();
 
         // Now we check with a linked table constraint
         let result = LinkedTableConstraint { table: &source_table, constraint: &source_table.constraints.first().unwrap()}
-                        .generate(&mut changeset, &existing_database, &publish_profile, &log);
+                        .generate(&mut change_set,
+                                  &existing_database,
+                                  &capabilities,
+                                  &publish_profile,
+                                  &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to create a new constraint
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
             ChangeInstruction::AddConstraint(ref table, ref constraint) => {
                 assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
                 match *constraint {
@@ -2128,7 +2284,7 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("ALTER TABLE my.contacts\n\
                           ADD CONSTRAINT fk_my_contacts_my_companies FOREIGN KEY (company_id) \
                           REFERENCES my.companies (id) MATCH SIMPLE ON UPDATE CASCADE ON DELETE NO ACTION".to_owned());
@@ -2154,17 +2310,25 @@ mod tests {
                 ]),
             });
         existing_database.tables.push(existing_table);
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_foreign_key_constraints = Toggle::Allow;
 
-        let mut changeset = Vec::new();
-        // This changeset gets generated at the table level
-        let result = (&source_table).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        // This change_set gets generated at the table level
+        let result = (&source_table).generate(&mut change_set,
+                                              &existing_database,
+                                              &capabilities,
+                                              &publish_profile,
+                                              &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to remove a constraint
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
             ChangeInstruction::DropConstraint(ref table, ref name) => {
                 assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
                 assert_that!(*name).is_equal_to("fk_my_contacts_my_companies".to_owned());
@@ -2173,7 +2337,7 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("ALTER TABLE my.contacts\nDROP CONSTRAINT fk_my_contacts_my_companies".to_owned());
     }
 
@@ -2208,29 +2372,41 @@ mod tests {
                 ]),
             });
         existing_database.tables.push(existing_table);
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_foreign_key_constraints = Toggle::Allow;
 
-        let mut changeset = Vec::new();
+        let mut change_set = Vec::new();
         // First, check that source table changes do nothing
-        let _ = (&source_table).generate(&mut changeset, &existing_database, &publish_profile, &log);
-        assert_that!(changeset).is_empty();
+        let _ = (&source_table).generate(&mut change_set,
+                                         &existing_database,
+                                         &capabilities,
+                                         &publish_profile,
+                                         &log);
+        assert_that!(change_set).is_empty();
 
         // Now we check with a linked table constraint
         let result = LinkedTableConstraint { table: &source_table, constraint: &source_table.constraints.first().unwrap()}
-                        .generate(&mut changeset, &existing_database, &publish_profile, &log);
+                        .generate(&mut change_set,
+                                  &existing_database,
+                                  &capabilities,
+                                  &publish_profile,
+                                  &log);
         assert_that!(result).is_ok();
 
         // Primary keys cannot be altered, so we drop/create
-        assert_that!(changeset).has_length(2);
-        match changeset[0] {
+        assert_that!(change_set).has_length(2);
+        match change_set[0] {
             ChangeInstruction::DropConstraint(ref table, ref name) => {
                 assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
                 assert_that!(*name).is_equal_to("fk_my_contacts_my_companies".to_owned());
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
-        match changeset[1] {
+        match change_set[1] {
             ChangeInstruction::AddConstraint(ref table, ref constraint) => {
                 assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
                 match *constraint {
@@ -2251,9 +2427,9 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("ALTER TABLE my.contacts\nDROP CONSTRAINT fk_my_contacts_my_companies".to_owned());
-        assert_that!(changeset[1].to_sql(&log))
+        assert_that!(change_set[1].to_sql(&log))
             .is_equal_to("ALTER TABLE my.contacts\n\
                           ADD CONSTRAINT fk_my_contacts_my_companies FOREIGN KEY (company_id) \
                           REFERENCES my.companies (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION".to_owned());
@@ -2283,14 +2459,22 @@ mod tests {
         // Create a database with no indexes defined.
         let existing_database = Package::new();
         let publish_profile = PublishProfile::default();
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
 
-        let mut changeset = Vec::new();
-        let result = (&source_index).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&source_index).generate(&mut change_set,
+                                              &existing_database,
+                                              &capabilities,
+                                              &publish_profile,
+                                              &log);
         assert_that!(result).is_ok();
 
         // We should have a single instruction to create a new index
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
             ChangeInstruction::AddIndex(ref index, concurrently) => {
                 assert_that!(index.name).is_equal_to("idx_contacts_first_name".to_owned());
                 assert_that!(index.table.to_string()).is_equal_to("public.contacts".to_owned());
@@ -2300,7 +2484,7 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("CREATE UNIQUE INDEX CONCURRENTLY idx_contacts_first_name \
                           ON public.contacts USING btree (first_name ASC NULLS LAST)".to_owned());
     }
@@ -2332,25 +2516,42 @@ mod tests {
             });
             Some(existing_database)
         }
-
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_indexes = Toggle::Error;
 
         // First of all, make sure an error is generated
-        let result = Delta::generate(&log, &source_package, existing_db(), "dbname".to_owned(), publish_profile);
+        let result = Delta::generate(&log,
+                                     &source_package,
+                                     existing_db(),
+                                     "dbname".to_owned(),
+                                     capabilities,
+                                     publish_profile);
         assert_that!(result).is_err();
         // Now run it again - it should be ok now
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_indexes = Toggle::Allow;
-        let result = Delta::generate(&log, &source_package, existing_db(), "dbname".to_owned(), publish_profile);
+        let result = Delta::generate(&log,
+                                     &source_package,
+                                     existing_db(),
+                                     "dbname".to_owned(),
+                                     capabilities,
+                                     publish_profile);
         assert_that!(result).is_ok();
-        let changeset = match result.unwrap() {
+        let change_set = match result.unwrap() {
             Delta(c) => c,
         };
 
         // We should have a single instruction to remove an index (first will be use database)
-        assert_that!(changeset).has_length(2);
-        match changeset[1] {
+        assert_that!(change_set).has_length(2);
+        match change_set[1] {
             ChangeInstruction::DropIndex(ref index, concurrently) => {
                 assert_that!(*index).is_equal_to("public.idx_contacts_first_name".to_owned());
                 assert_that!(concurrently).is_true();
@@ -2359,7 +2560,7 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[1].to_sql(&log))
+        assert_that!(change_set[1].to_sql(&log))
             .is_equal_to("DROP INDEX CONCURRENTLY IF EXISTS public.idx_contacts_first_name".to_owned());
     }
 
@@ -2408,22 +2609,30 @@ mod tests {
             index_type: Some(IndexType::BTree),
             storage_parameters: None,
         });
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
-        let result = (&source_index).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&source_index).generate(&mut change_set,
+                                              &existing_database,
+                                              &capabilities,
+                                              &publish_profile,
+                                              &log);
         assert_that!(result).is_ok();
 
         // We should have two instructions to drop/create a new index
-        assert_that!(changeset).has_length(2);
-        match changeset[0] {
+        assert_that!(change_set).has_length(2);
+        match change_set[0] {
             ChangeInstruction::DropIndex(ref index_name, concurrently) => {
                 assert_that!(*index_name).is_equal_to("public.idx_contacts_name".to_owned());
                 assert_that!(concurrently).is_true();
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
-        match changeset[1] {
+        match change_set[1] {
             ChangeInstruction::AddIndex(ref index, concurrently) => {
                 assert_that!(index.name).is_equal_to("idx_contacts_name".to_owned());
                 assert_that!(index.table.to_string()).is_equal_to("public.contacts".to_owned());
@@ -2433,82 +2642,98 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("DROP INDEX CONCURRENTLY IF EXISTS public.idx_contacts_name".to_owned());
-        assert_that!(changeset[1].to_sql(&log))
+        assert_that!(change_set[1].to_sql(&log))
             .is_equal_to("CREATE INDEX CONCURRENTLY idx_contacts_name \
                           ON public.contacts USING btree (first_name ASC NULLS LAST, last_name DESC NULLS FIRST)".to_owned());
     }
 
     #[test]
-    fn it_can_create_an_extension_that_exists_and_isnt_installed_with_version() {
+    fn it_can_create_an_extension_that_exists_and_is_not_installed_with_version() {
         let log = empty_logger();
         let requested_extension = ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(2, 3, Some(7))),
-            installed: None,
+            name: &"postgis".to_owned(),
+            version: &Some(Semver::new(2, 3, Some(7))),
         };
 
         // Create a database with a single extension available.
-        let mut existing_database = Package::new();
-        existing_database.extensions.push(ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(2, 3, Some(7))),
-            installed: Some(false),
-        });
+        let existing_database = Package::new();
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: vec![
+                Extension {
+                    name: "postgis".to_owned(),
+                    version: Semver::new(2, 3, Some(7)),
+                    installed: false,
+                }
+            ],
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
-        let result = (&requested_extension).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&requested_extension).generate(&mut change_set,
+                                                     &existing_database,
+                                                     &capabilities,
+                                                     &publish_profile,
+                                                     &log);
         assert_that!(result).is_ok();
 
         // We should have one instruction to create an extension
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
-            ChangeInstruction::CreateExtension(ref extension) => {
-                assert_that!(extension.name).is_equal_to("postgis".to_owned());
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
+            ChangeInstruction::CreateExtension(ref name, ref _version) => {
+                assert_that!(name).is_equal_to(&"postgis".to_owned());
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("CREATE EXTENSION postgis WITH VERSION \"2.3.7\"".to_owned());
     }
 
     #[test]
-    fn it_can_create_an_extension_that_exists_and_isnt_installed_without_version() {
+    fn it_can_create_an_extension_that_exists_and_is_not_installed_without_version() {
         let log = empty_logger();
         let requested_extension = ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: None,
-            installed: None,
+            name: &"postgis".to_owned(),
+            version: &None,
         };
 
         // Create a database with a single extension available.
-        let mut existing_database = Package::new();
-        existing_database.extensions.push(ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(2, 3, Some(7))),
-            installed: Some(false),
-        });
+        let existing_database = Package::new();
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: vec![
+                Extension {
+                    name: "postgis".to_owned(),
+                    version: Semver::new(2, 3, Some(7)),
+                    installed: false,
+                }
+            ],
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
-        let result = (&requested_extension).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&requested_extension).generate(&mut change_set,
+                                                     &existing_database,
+                                                     &capabilities,
+                                                     &publish_profile,
+                                                     &log);
         assert_that!(result).is_ok();
 
         // We should have one instruction to create an extension
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
-            ChangeInstruction::CreateExtension(ref extension) => {
-                assert_that!(extension.name).is_equal_to("postgis".to_owned());
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
+            ChangeInstruction::CreateExtension(ref name, ref _version) => {
+                assert_that!(name).is_equal_to(&"postgis".to_owned());
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("CREATE EXTENSION postgis".to_owned());
     }
 
@@ -2516,22 +2741,30 @@ mod tests {
     fn it_errors_when_creating_an_extension_that_exists_and_different_version() {
         let log = empty_logger();
         let requested_extension = ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(2, 4, Some(7))),
-            installed: None,
+            name: &"postgis".to_owned(),
+            version: &Some(Semver::new(2, 4, Some(7))),
         };
 
         // Create a database with a single extension available.
-        let mut existing_database = Package::new();
-        existing_database.extensions.push(ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(2, 3, Some(7))),
-            installed: Some(false),
-        });
+        let existing_database = Package::new();
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: vec![
+                Extension {
+                    name: "postgis".to_owned(),
+                    version: Semver::new(2, 3, Some(7)),
+                    installed: false,
+                }
+            ],
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
-        let result = (&requested_extension).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&requested_extension).generate(&mut change_set,
+                                                     &existing_database,
+                                                     &capabilities,
+                                                     &publish_profile,
+                                                     &log);
         assert_that!(result).is_err();
 
         let err = result.err().unwrap();
@@ -2540,20 +2773,27 @@ mod tests {
     }
 
     #[test]
-    fn it_errors_when_creating_an_extension_that_doesnt_exist() {
+    fn it_errors_when_creating_an_extension_that_does_not_exist() {
         let log = empty_logger();
         let requested_extension = ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(2, 3, Some(7))),
-            installed: None,
+            name: &"postgis".to_owned(),
+            version: &Some(Semver::new(2, 3, Some(7))),
         };
 
-        // Create a database with a single extension available.
+        // Create a database with no extensions available.
         let existing_database = Package::new();
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: Vec::new(),
+        };
         let publish_profile = PublishProfile::default();
 
-        let mut changeset = Vec::new();
-        let result = (&requested_extension).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&requested_extension).generate(&mut change_set,
+                                                     &existing_database,
+                                                     &capabilities,
+                                                     &publish_profile,
+                                                     &log);
         assert_that!(result).is_err();
 
         let err = result.err().unwrap();
@@ -2565,111 +2805,135 @@ mod tests {
     fn it_can_upgrade_an_installed_extension_with_newer_version_specified_and_available() {
         let log = empty_logger();
         let requested_extension = ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(3, 8, None)),
-            installed: None,
+            name: &"postgis".to_owned(),
+            version: &Some(Semver::new(3, 8, None)),
         };
 
-        // Create a database with a single extension available.
-        let mut existing_database = Package::new();
-        existing_database.extensions.push(ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(2, 3, Some(7))),
-            installed: Some(true),
-        });
-        existing_database.extensions.push(ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(3, 8, None)),
-            installed: Some(false),
-        });
+        // Create a database with two extensions available.
+        let existing_database = Package::new();
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: vec![
+                Extension {
+                    name: "postgis".to_owned(),
+                    version: Semver::new(2, 3, Some(7)),
+                    installed: true,
+                },
+                Extension {
+                    name: "postgis".to_owned(),
+                    version: Semver::new(3, 8, None),
+                    installed: false,
+                },
+            ],
+        };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.upgrade_extensions = Toggle::Allow;
 
-        let mut changeset = Vec::new();
-        let result = (&requested_extension).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&requested_extension).generate(&mut change_set,
+                                                     &existing_database,
+                                                     &capabilities,
+                                                     &publish_profile,
+                                                     &log);
         assert_that!(result).is_ok();
 
         // We should have one instruction to upgrade an extension
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
-            ChangeInstruction::UpgradeExtension(ref extension) => {
-                assert_that!(extension.name).is_equal_to("postgis".to_owned());
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
+            ChangeInstruction::UpgradeExtension(ref name, ref _version) => {
+                assert_that!(name).is_equal_to(&"postgis".to_owned());
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("ALTER EXTENSION postgis UPDATE TO \"3.8\"".to_owned());
     }
 
 
     #[test]
-    fn it_doesnt_modify_an_extension_that_is_already_installed() {
+    fn it_does_not_modify_an_extension_that_is_already_installed() {
         let log = empty_logger();
         let requested_extension = ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: None,
-            installed: None,
+            name: &"postgis".to_owned(),
+            version: &None,
         };
 
         // Create a database with a single extension available.
-        let mut existing_database = Package::new();
-        existing_database.extensions.push(ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(2, 3, Some(7))),
-            installed: Some(true),
-        });
+        let existing_database = Package::new();
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: vec![
+                Extension {
+                    name: "postgis".to_owned(),
+                    version: Semver::new(2, 3, Some(7)),
+                    installed: true,
+                }
+            ],
+        };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.upgrade_extensions = Toggle::Allow;
 
-        let mut changeset = Vec::new();
-        let result = (&requested_extension).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&requested_extension).generate(&mut change_set,
+                                                     &existing_database,
+                                                     &capabilities,
+                                                     &publish_profile,
+                                                     &log);
         assert_that!(result).is_ok();
 
         // We should have no instructions
-        assert_that!(changeset).is_empty();
+        assert_that!(change_set).is_empty();
     }
 
     #[test]
     fn it_can_upgrade_an_installed_extension_with_no_version_specified_and_newer_version_available_when_profile_set_to_allow() {
         let log = empty_logger();
         let requested_extension = ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: None,
-            installed: None,
+            name: &"postgis".to_owned(),
+            version: &None,
         };
 
-        // Create a database with a single extension available.
-        let mut existing_database = Package::new();
-        existing_database.extensions.push(ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(2, 3, Some(7))),
-            installed: Some(true),
-        });
-        existing_database.extensions.push(ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(3, 8, None)),
-            installed: Some(false),
-        });
+        // Create a database with multiple extensions available.
+        let existing_database = Package::new();
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: vec![
+                Extension {
+                    name: "postgis".to_owned(),
+                    version: Semver::new(2, 3, Some(7)),
+                    installed: true,
+                },
+                Extension {
+                    name: "postgis".to_owned(),
+                    version: Semver::new(3, 8, None),
+                    installed: false,
+                }
+            ],
+        };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.upgrade_extensions = Toggle::Allow;
 
-        let mut changeset = Vec::new();
-        let result = (&requested_extension).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&requested_extension).generate(&mut change_set,
+                                                     &existing_database,
+                                                     &capabilities,
+                                                     &publish_profile,
+                                                     &log);
         assert_that!(result).is_ok();
 
         // We should have one instruction to upgrade an extension
-        assert_that!(changeset).has_length(1);
-        match changeset[0] {
-            ChangeInstruction::UpgradeExtension(ref extension) => {
-                assert_that!(extension.name).is_equal_to("postgis".to_owned());
+        assert_that!(change_set).has_length(1);
+        match change_set[0] {
+            ChangeInstruction::UpgradeExtension(ref name, ref _version) => {
+                assert_that!(name).is_equal_to(&"postgis".to_owned());
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(changeset[0].to_sql(&log))
+        assert_that!(change_set[0].to_sql(&log))
             .is_equal_to("ALTER EXTENSION postgis UPDATE".to_owned());
     }
 
@@ -2677,60 +2941,76 @@ mod tests {
     fn it_doesnt_upgrade_an_installed_extension_with_no_version_specified_and_newer_version_available_when_profile_set_to_ignore() {
         let log = empty_logger();
         let requested_extension = ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: None,
-            installed: None,
+            name: &"postgis".to_owned(),
+            version: &None,
         };
 
-        // Create a database with a single extension available.
-        let mut existing_database = Package::new();
-        existing_database.extensions.push(ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(2, 3, Some(7))),
-            installed: Some(true),
-        });
-        existing_database.extensions.push(ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(3, 8, None)),
-            installed: Some(false),
-        });
+        // Create a database with multiple extensions available.
+        let existing_database = Package::new();
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: vec![
+                Extension {
+                    name: "postgis".to_owned(),
+                    version: Semver::new(2, 3, Some(7)),
+                    installed: true,
+                },
+                Extension {
+                    name: "postgis".to_owned(),
+                    version: Semver::new(3, 8, None),
+                    installed: false,
+                },
+            ],
+        };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.upgrade_extensions = Toggle::Ignore;
 
-        let mut changeset = Vec::new();
-        let result = (&requested_extension).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&requested_extension).generate(&mut change_set,
+                                                     &existing_database,
+                                                     &capabilities,
+                                                     &publish_profile,
+                                                     &log);
         assert_that!(result).is_ok();
 
         // We should have no instructions
-        assert_that!(changeset).is_empty();
+        assert_that!(change_set).is_empty();
     }
 
     #[test]
     fn it_doesnt_upgrade_an_installed_extension_with_no_version_specified_and_newer_version_available_when_profile_set_to_error() {
         let log = empty_logger();
         let requested_extension = ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: None,
-            installed: None,
+            name: &"postgis".to_owned(),
+            version: &None,
         };
 
         // Create a database with a single extension available.
-        let mut existing_database = Package::new();
-        existing_database.extensions.push(ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(2, 3, Some(7))),
-            installed: Some(true),
-        });
-        existing_database.extensions.push(ExtensionDefinition {
-            name: "postgis".to_owned(),
-            version: Some(Semver::new(3, 8, None)),
-            installed: Some(false),
-        });
+        let existing_database = Package::new();
+        let capabilities = Capabilities {
+            server_version: Semver::new(9, 6, None),
+            extensions: vec![
+                Extension {
+                    name: "postgis".to_owned(),
+                    version: Semver::new(2, 3, Some(7)),
+                    installed: true,
+                },
+                Extension {
+                    name: "postgis".to_owned(),
+                    version: Semver::new(3, 8, None),
+                    installed: false,
+                },
+            ],
+        };
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.upgrade_extensions = Toggle::Error;
 
-        let mut changeset = Vec::new();
-        let result = (&requested_extension).generate(&mut changeset, &existing_database, &publish_profile, &log);
+        let mut change_set = Vec::new();
+        let result = (&requested_extension).generate(&mut change_set,
+                                                     &existing_database,
+                                                     &capabilities,
+                                                     &publish_profile,
+                                                     &log);
         assert_that!(result).is_err();
 
         let err = result.err().unwrap();

--- a/psqlpack/src/model/mod.rs
+++ b/psqlpack/src/model/mod.rs
@@ -7,13 +7,21 @@ macro_rules! dbtry {
     };
 }
 
+macro_rules! map {
+    ($expr:expr) => {{
+        $expr.iter().map(|row| row.into()).collect()
+    }};
+}
+
+mod capabilities;
 mod profiles;
 mod project;
 mod package;
 mod delta;
 pub mod template;
 
+pub use self::capabilities::{Capabilities, Extension};
 pub use self::profiles::{GenerationOptions, PublishProfile, Toggle};
-pub use self::project::Project;
+pub use self::project::{Dependency, Project};
 pub use self::package::{Node, Package, ValidationKind};
 pub use self::delta::Delta;

--- a/psqlpack/src/model/package.rs
+++ b/psqlpack/src/model/package.rs
@@ -54,12 +54,15 @@ macro_rules! map {
 
 static Q_DATABASE_EXISTS: &'static str = "SELECT 1 FROM pg_database WHERE datname=$1;";
 
-static Q_EXTENSIONS: &'static str = "SELECT extname, extversion
-                                     FROM pg_extension
-                                     WHERE extowner <> 10";
+static Q_EXTENSIONS: &'static str = "SELECT name, version, installed, requires
+                                     FROM pg_available_extension_versions ";
 impl<'row> From<Row<'row>> for ExtensionDefinition {
     fn from(row: Row) -> Self {
-        ExtensionDefinition { name: row.get(0) }
+        ExtensionDefinition {
+            name: row.get(0),
+            version: row.get(1),
+            installed: row.get(2),
+        }
     }
 }
 
@@ -680,7 +683,7 @@ impl Package {
         // Get a list of indexes
         let mut indexes = Vec::new();
         // TODO: Find a better way to store queries against semvers. Mod's?
-        let index_query = match version.cmp(&Semver::new(9, 6, 0)) {
+        let index_query = match version.cmp(&Semver::new(9, 6, None)) {
             ::std::cmp::Ordering::Less => Q_INDEXES_94_THRU_96,
             _ => Q_INDEXES,
         };

--- a/psqlpack/src/model/profiles.rs
+++ b/psqlpack/src/model/profiles.rs
@@ -39,6 +39,13 @@ impl Toggle {
     }
 }
 
+struct Bool;
+impl Bool {
+    fn t() -> bool {
+        true
+    }
+}
+
 #[derive(Deserialize, Serialize)]
 pub struct GenerationOptions {
     /// If set to true, the database will always be recereated
@@ -46,25 +53,32 @@ pub struct GenerationOptions {
 
     /// Enum values are typically unsafe to delete. If set to Allow, psqlpack will attempt to delete.
     /// Default: Error
-    #[serde(rename = "dropEnumValues")] pub drop_enum_values: Toggle,
+    #[serde(rename = "dropEnumValues", default = "Toggle::error")]
+    pub drop_enum_values: Toggle,
     /// Tables may have data in them which may not be intended to be deleted. If set to Allow, psqlpack will drop the table.
     /// Default: Error
-    #[serde(rename = "dropTables")] pub drop_tables: Toggle,
+    #[serde(rename = "dropTables", default = "Toggle::error")]
+    pub drop_tables: Toggle,
     /// Columns may have data in them which may not be intended to be deleted. If set to Allow, psqlpack will drop the column.
     /// Default: Error
-    #[serde(rename = "dropColumns")] pub drop_columns: Toggle,
+    #[serde(rename = "dropColumns", default = "Toggle::error")]
+    pub drop_columns: Toggle,
     /// Primary Keys define how a table is looked up on disk. If set to Allow, psqlpack will drop the primary key.
     /// Default: Error
-    #[serde(rename = "dropPrimaryKeyConstraints")] pub drop_primary_key_constraints: Toggle,
+    #[serde(rename = "dropPrimaryKeyConstraints", default = "Toggle::error")]
+    pub drop_primary_key_constraints: Toggle,
     /// Foreign Keys define a constraint to another table. If set to Allow, psqlpack will drop the foreign key.
     /// Default: Allow
-    #[serde(rename = "dropForeignKeyConstraints")] pub drop_foreign_key_constraints: Toggle,
+    #[serde(rename = "dropForeignKeyConstraints", default = "Toggle::allow")]
+    pub drop_foreign_key_constraints: Toggle,
     /// Functions may not be intended to be deleted. If set to Allow, psqlpack will drop the function.
     /// Default: Error
-    #[serde(rename = "dropFunctions")] pub drop_functions: Toggle,
+    #[serde(rename = "dropFunctions", default = "Toggle::error")]
+    pub drop_functions: Toggle,
     /// Indexes may not be intended to be deleted. If set to Allow, psqlpack will drop the index.
     /// Default: Allow
-    #[serde(rename = "dropIndexes")] pub drop_indexes: Toggle,
+    #[serde(rename = "dropIndexes", default = "Toggle::allow")]
+    pub drop_indexes: Toggle,
 
     /// Extensions may not be intended to be upgraded automatically. If set to Allow, psqlpack will upgrade the extension as necessary.
     /// Default: Ignore
@@ -73,7 +87,8 @@ pub struct GenerationOptions {
 
     /// Forces index changes to be made concurrently to avoid locking on table writes.
     /// Default: true
-    #[serde(rename = "forceConcurrentIndexes")] pub force_concurrent_indexes: bool,
+    #[serde(rename = "forceConcurrentIndexes", default = "Bool::t")]
+    pub force_concurrent_indexes: bool,
 }
 
 impl Default for PublishProfile {

--- a/psqlpack/src/model/profiles.rs
+++ b/psqlpack/src/model/profiles.rs
@@ -25,6 +25,20 @@ pub enum Toggle {
     Error,
 }
 
+impl Toggle {
+    fn allow() -> Toggle {
+        Toggle::Allow
+    }
+
+    fn ignore() -> Toggle {
+        Toggle::Ignore
+    }
+
+    fn error() -> Toggle {
+        Toggle::Error
+    }
+}
+
 #[derive(Deserialize, Serialize)]
 pub struct GenerationOptions {
     /// If set to true, the database will always be recereated
@@ -52,6 +66,11 @@ pub struct GenerationOptions {
     /// Default: Allow
     #[serde(rename = "dropIndexes")] pub drop_indexes: Toggle,
 
+    /// Extensions may not be intended to be upgraded automatically. If set to Allow, psqlpack will upgrade the extension as necessary.
+    /// Default: Ignore
+    #[serde(rename = "upgradeExtensions", default = "Toggle::ignore")]
+    pub upgrade_extensions: Toggle,
+
     /// Forces index changes to be made concurrently to avoid locking on table writes.
     /// Default: true
     #[serde(rename = "forceConcurrentIndexes")] pub force_concurrent_indexes: bool,
@@ -71,6 +90,8 @@ impl Default for PublishProfile {
                 drop_foreign_key_constraints: Toggle::Allow,
                 drop_functions: Toggle::Error,
                 drop_indexes: Toggle::Allow,
+
+                upgrade_extensions: Toggle::Ignore,
 
                 force_concurrent_indexes: true,
             },

--- a/psqlpack/src/model/project.rs
+++ b/psqlpack/src/model/project.rs
@@ -1,12 +1,13 @@
 use std::default::Default;
+use std::fs::{self, File};
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::fs::{self, File};
 
-use slog::Logger;
-use serde_json;
 use glob::glob;
+use serde_json;
+use slog::Logger;
 
+use crate::Semver;
 use sql::ast::*;
 use sql::lexer;
 use sql::parser::StatementListParser;
@@ -36,22 +37,35 @@ pub struct Project {
     pub version: String,
 
     /// The default schema for the database. Typically `public`
-    #[serde(rename = "defaultSchema")] pub default_schema: String,
+    #[serde(rename = "defaultSchema")]
+    pub default_schema: String,
 
     /// An array of scripts to run before anything is deployed
-    #[serde(rename = "preDeployScripts")] pub pre_deploy_scripts: Vec<String>,
+    #[serde(rename = "preDeployScripts")]
+    pub pre_deploy_scripts: Vec<String>,
 
     /// An array of scripts to run after everything has been deployed
-    #[serde(rename = "postDeployScripts")] pub post_deploy_scripts: Vec<String>,
+    #[serde(rename = "postDeployScripts")]
+    pub post_deploy_scripts: Vec<String>,
 
     /// An array of extensions to include within this project
-    #[serde(skip_serializing_if = "Option::is_none")] pub extensions: Option<Vec<ExtensionDefinition>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<Vec<Dependency>>,
 
     /// An array of globs representing files/folders to be included within your project. Defaults to `["**/*.sql"]`.
-    #[serde(rename = "fileIncludeGlobs", skip_serializing_if = "Option::is_none")] pub include_globs: Option<Vec<String>>,
+    #[serde(rename = "fileIncludeGlobs", skip_serializing_if = "Option::is_none")]
+    pub include_globs: Option<Vec<String>>,
 
     /// An array of globs representing files/folders to be excluded within your project.
-    #[serde(rename = "fileExcludeGlobs", skip_serializing_if = "Option::is_none")] pub exclude_globs: Option<Vec<String>>,
+    #[serde(rename = "fileExcludeGlobs", skip_serializing_if = "Option::is_none")]
+    pub exclude_globs: Option<Vec<String>>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Dependency {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<Semver>,
 }
 
 impl Default for Project {
@@ -138,14 +152,6 @@ impl Project {
 
         // Start the package
         let mut package = Package::new();
-
-        // Add extensions
-        if let Some(ref extensions) = self.extensions {
-            for extension in extensions {
-                package.push_extension(extension.clone());
-            }
-        }
-
         let mut errors: Vec<PsqlpackError> = Vec::new();
 
         // Enumerate the glob paths
@@ -205,7 +211,9 @@ impl Project {
                         for statement in statement_list {
                             dump_statement!(log, statement);
                             match statement {
-                                Statement::Extension(_) => warn!(log, "Extension statement found, ignoring"),
+                                Statement::Error(kind) => {
+                                    errors.push(HandledParseError(kind).into());
+                                },
                                 Statement::Function(function_definition) => package.push_function(function_definition),
                                 Statement::Index(index_definition) => package.push_index(index_definition),
                                 Statement::Schema(schema_definition) => package.push_schema(schema_definition),
@@ -321,11 +329,40 @@ mod tests {
         assert_that!(result).is_ok().has_length(3);
         let result = result.unwrap();
         let result : Vec<&str> = result.iter().map(|x| x.to_str().unwrap()).collect();
+        assert_that!(result).does_not_contain(&"../samples/simple/public/tables/public.organisation.sql");
         assert_that!(result).contains_all_of(&vec![
             &"../samples/simple/public/tables/public.expense_status.sql",
             &"../samples/simple/public/tables/public.tax_table.sql",
             &"../samples/simple/public/tables/public.vendor.sql",
         ]);
+    }
+
+    #[test]
+    fn it_can_iterate_custom_exclude_globs_correctly_2() {
+        // This test relies on the `simple` samples directory
+        let parent = Path::new("../samples/complex");
+        let project = Project {
+            project_file_path: None,
+            version: "1.0".into(),
+            default_schema: "public".into(),
+            pre_deploy_scripts: Vec::new(),
+            post_deploy_scripts: Vec::new(),
+            extensions: None,
+            include_globs: None,
+            exclude_globs: Some(vec![
+                "**/geo/**/*.sql".into(),
+                "**/geo.*".into(),
+            ]),
+        };
+        let result = project.walk_files(&parent);
+
+        // Check the expected files were returned
+        assert_that!(result).is_ok();
+        let result = result.unwrap();
+        let result : Vec<&str> = result.iter().map(|x| x.to_str().unwrap()).collect();
+        assert_that!(result).does_not_contain(&"../samples/complex/geo/functions/fn_do_any_coordinates_fall_inside.sql");
+        assert_that!(result).does_not_contain(&"../samples/complex/geo/tables/states.sql");
+        assert_that!(result).does_not_contain(&"../samples/complex/scripts/seed/geo.states.sql");
     }
 
     #[test]

--- a/psqlpack/src/model/project.rs
+++ b/psqlpack/src/model/project.rs
@@ -154,6 +154,16 @@ impl Project {
         let mut package = Package::new();
         let mut errors: Vec<PsqlpackError> = Vec::new();
 
+        // Add extensions into package
+        if let Some(ref extensions) = self.extensions {
+            for extension in extensions {
+                package.push_extension(Dependency {
+                    name: extension.name.clone(),
+                    version: extension.version,
+                });
+            }
+        }
+
         // Enumerate the glob paths
         for path in self.walk_files(&parent)? {
             let log = log.new(o!("file" => path.to_str().unwrap().to_owned()));

--- a/psqlpack/src/model/project.rs
+++ b/psqlpack/src/model/project.rs
@@ -45,7 +45,7 @@ pub struct Project {
     #[serde(rename = "postDeployScripts")] pub post_deploy_scripts: Vec<String>,
 
     /// An array of extensions to include within this project
-    #[serde(skip_serializing_if = "Option::is_none")] pub extensions: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")] pub extensions: Option<Vec<ExtensionDefinition>>,
 
     /// An array of globs representing files/folders to be included within your project. Defaults to `["**/*.sql"]`.
     #[serde(rename = "fileIncludeGlobs", skip_serializing_if = "Option::is_none")] pub include_globs: Option<Vec<String>>,
@@ -142,9 +142,7 @@ impl Project {
         // Add extensions
         if let Some(ref extensions) = self.extensions {
             for extension in extensions {
-                package.push_extension(ExtensionDefinition {
-                    name: extension.clone(),
-                });
+                package.push_extension(extension.clone());
             }
         }
 

--- a/psqlpack/src/semver.rs
+++ b/psqlpack/src/semver.rs
@@ -1,11 +1,7 @@
 use std::cmp;
 use std::fmt;
-use postgres::{Connection as PostgresConnection};
-use postgres::types::{FromSql, Type, TEXT};
+use std::str::FromStr;
 use regex::Regex;
-
-use errors::PsqlpackResult;
-use errors::PsqlpackErrorKind::*;
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct Semver {
@@ -15,11 +11,11 @@ pub struct Semver {
 }
 
 impl Semver {
-    pub fn new(major: u32, minor: u32, rev: Option<u32>) -> Self {
+    pub fn new(major: u32, minor: u32, revision: Option<u32>) -> Self {
         Semver {
-            major: major,
-            minor: minor,
-            revision: rev,
+            major,
+            minor,
+            revision,
         }
     }
 }
@@ -74,67 +70,52 @@ impl cmp::Ord for Semver {
     }
 }
 
-pub trait ServerVersion {
-    fn server_version(&self) -> PsqlpackResult<Semver>;
-}
-
 lazy_static! {
     static ref VERSION : Regex = Regex::new("(\\d+)(\\.(\\d+))?(\\.(\\d+))?").unwrap();
 }
 
-fn parse_version_string(version: &str) -> Semver {
-    fn get_u32(caps: &::regex::Captures<'_>, pos: usize, optional: bool) -> Option<u32> {
-        if let Some(rev) = caps.get(pos) {
-            Some(rev.as_str().parse::<u32>().unwrap())
-        } else {
-            if optional {
-                None
+impl FromStr for Semver {
+    type Err = String;
+
+    fn from_str(version: &str) -> Result<Self, Self::Err> {
+        fn get_u32(caps: &::regex::Captures<'_>, pos: usize, optional: bool) -> Option<u32> {
+            if let Some(rev) = caps.get(pos) {
+                Some(rev.as_str().parse::<u32>().unwrap())
             } else {
-                Some(0)
+                if optional {
+                    None
+                } else {
+                    Some(0)
+                }
             }
         }
-    }
 
-    let caps = VERSION.captures(version).unwrap();
-    let major = get_u32(&caps, 1, false).unwrap();
-    let minor = get_u32(&caps, 3, false).unwrap();
-    let revision = get_u32(&caps, 5, true);
-    Semver {
-        major: major,
-        minor: minor,
-        revision: revision,
-    }
-}
-
-impl ServerVersion for PostgresConnection {
-    fn server_version(&self) -> PsqlpackResult<Semver> {
-        let rows = self.query("SHOW SERVER_VERSION;", &[])
-                      .map_err(|e| DatabaseError(format!("Failed to retrieve server version: {}", e)))?;
-        let row = rows.iter().last();
-        if let Some(row) = row {
-            let version: String = row.get(0);
-            Ok(parse_version_string(&version[..]))
-        } else {
-            bail!(DatabaseError("Failed to retrieve version from server".into()))
-        }
-    }
-}
-
-impl FromSql for Semver {
-    // TODO: Better error handling
-    fn from_sql(_: &Type, raw: &[u8]) -> Result<Semver, Box<::std::error::Error + Sync + Send>> {
-        let version = String::from_utf8_lossy(raw);
-        Ok(parse_version_string(&version))
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        *ty == TEXT
+        let caps = match VERSION.captures(version) {
+            Some(x) => x,
+            None => return Err("Unexpected version format".into()),
+        };
+        let major = match get_u32(&caps, 1, false) {
+            Some(x) => x,
+            None => return Err("Unexpected major part".into()),
+        };
+        let minor = match get_u32(&caps, 3, false) {
+            Some(x) => x,
+            None => return Err("Unexpected minor part".into()),
+        };
+        let revision = get_u32(&caps, 5, true);
+        Ok(Semver {
+            major,
+            minor,
+            revision,
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::parse_version_string;
+    use std::str::FromStr;
+    use super::Semver;
+
     use spectral::prelude::*;
 
     #[test]
@@ -146,8 +127,9 @@ mod tests {
             ("9.6.9", "9.6.9"),
         ];
         for &(given, expected) in tests {
-            let parsed = parse_version_string(given);
-            assert_that!(parsed.to_string()).is_equal_to(expected.to_string());
+            let parsed = Semver::from_str(given);
+            assert_that!(parsed).is_ok();
+            assert_that!(parsed.unwrap().to_string()).is_equal_to(expected.to_string());
         }
     }
 }

--- a/psqlpack/src/semver.rs
+++ b/psqlpack/src/semver.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 use errors::PsqlpackResult;
 use errors::PsqlpackErrorKind::*;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct Semver {
     major: u32,
     minor: u32,

--- a/psqlpack/src/sql/ast.rs
+++ b/psqlpack/src/sql/ast.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use crate::Semver;
+
 #[derive(Debug)]
 pub enum Statement {
     Extension(ExtensionDefinition),
@@ -154,9 +156,15 @@ pub struct SchemaDefinition {
     pub name: String,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ExtensionDefinition {
     pub name: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<Semver>,
+
+    #[serde(skip)]
+    pub installed: Option<bool>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/psqlpack/src/sql/ast.rs
+++ b/psqlpack/src/sql/ast.rs
@@ -1,10 +1,22 @@
 use std::fmt;
 
-use crate::Semver;
+#[derive(Debug)]
+pub enum ErrorKind {
+    ExtensionNotSupported(String),
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ErrorKind::ExtensionNotSupported(ref name) =>
+                write!(f, "Extensions definined in SQL not supported (found {}). Please define extensions within the project file.", name),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum Statement {
-    Extension(ExtensionDefinition),
+    Error(ErrorKind),
     Function(FunctionDefinition),
     Index(IndexDefinition),
     Schema(SchemaDefinition),
@@ -154,17 +166,6 @@ pub struct ColumnDefinition {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct SchemaDefinition {
     pub name: String,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct ExtensionDefinition {
-    pub name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<Semver>,
-
-    #[serde(skip)]
-    pub installed: Option<bool>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/psqlpack/src/sql/parser.lalrpop
+++ b/psqlpack/src/sql/parser.lalrpop
@@ -119,11 +119,7 @@ pub StatementList: Vec<Statement> = {
 };
 
 Statement: Statement = {
-    CREATE EXTENSION <name:Ident> ";"? => Statement::Extension(ExtensionDefinition {
-        name: name,
-        version: None,
-        installed: None, // We want it installed, however we don't know if it is or isn't.
-    }),
+    CREATE EXTENSION <name:Ident> ";"? => Statement::Error(ErrorKind::ExtensionNotSupported(name)),
     CREATE (OR REPLACE)? FUNCTION <name:ObjectName> "(" ")" RETURNS <return_type:FunctionReturnType> AS <body:Literal> LANGUAGE <lang:FunctionType> ";"? => Statement::Function(FunctionDefinition {
         name: name,
         arguments: Vec::new(),

--- a/psqlpack/src/sql/parser.lalrpop
+++ b/psqlpack/src/sql/parser.lalrpop
@@ -122,7 +122,7 @@ Statement: Statement = {
     CREATE EXTENSION <name:Ident> ";"? => Statement::Extension(ExtensionDefinition {
         name: name,
         version: None,
-        installed: None,
+        installed: None, // We want it installed, however we don't know if it is or isn't.
     }),
     CREATE (OR REPLACE)? FUNCTION <name:ObjectName> "(" ")" RETURNS <return_type:FunctionReturnType> AS <body:Literal> LANGUAGE <lang:FunctionType> ";"? => Statement::Function(FunctionDefinition {
         name: name,

--- a/psqlpack/src/sql/parser.lalrpop
+++ b/psqlpack/src/sql/parser.lalrpop
@@ -121,6 +121,8 @@ pub StatementList: Vec<Statement> = {
 Statement: Statement = {
     CREATE EXTENSION <name:Ident> ";"? => Statement::Extension(ExtensionDefinition {
         name: name,
+        version: None,
+        installed: None,
     }),
     CREATE (OR REPLACE)? FUNCTION <name:ObjectName> "(" ")" RETURNS <return_type:FunctionReturnType> AS <body:Literal> LANGUAGE <lang:FunctionType> ";"? => Statement::Function(FunctionDefinition {
         name: name,

--- a/psqlpack/tests/common/mod.rs
+++ b/psqlpack/tests/common/mod.rs
@@ -7,10 +7,17 @@ macro_rules! drop_db {
     }};
 }
 
+macro_rules! dump_capabilities {
+    ($connection: expr) => {{
+        let log = Logger::root(Discard.fuse(), o!());
+        let capabilities = Capabilities::from_connection(&log, &$connection).unwrap();
+        println!("PG Version: {}", capabilities.server_version);
+    }};
+}
+
 macro_rules! create_db {
     ($connection:expr) => {{
         let conn = $connection.connect_host().unwrap();
-        println!("PG Version: {}", conn.server_version().unwrap());
         let result = conn.query("SELECT 1 FROM pg_database WHERE datname=$1", &[&$connection.database()]).unwrap();
         if result.is_empty() {
             conn.batch_execute(&format!("CREATE DATABASE {}", $connection.database())).unwrap();

--- a/psqlpack/tests/publish.rs
+++ b/psqlpack/tests/publish.rs
@@ -22,7 +22,8 @@ macro_rules! publish_package {
 
         // Create a target package from connection string
         let log = Logger::root(Discard.fuse(), o!());
-        let target_package = Package::from_connection(&log, &$connection).unwrap();
+        let capabilities = Capabilities::from_connection(&log, &$connection).unwrap();
+        let target_package = Package::from_connection(&log, &$connection, &capabilities).unwrap();
 
         // Generate delta and apply
         let delta = Delta::generate(
@@ -30,12 +31,14 @@ macro_rules! publish_package {
             &$package,
             target_package,
             $db_name.into(),
+            capabilities,
             publish_profile,
         ).unwrap();
         delta.apply(&log, &$connection).unwrap();
 
         // Confirm db exists with data
-        Package::from_connection(&log, &$connection).unwrap().unwrap()
+        let capabilities = Capabilities::from_connection(&log, &$connection).unwrap();
+        Package::from_connection(&log, &$connection, &capabilities).unwrap().unwrap()
     }};
 }
 
@@ -63,6 +66,7 @@ fn it_can_add_a_new_table_to_an_existing_database() {
 
     // Preliminary: create a database with no tables
     let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
+    dump_capabilities!(connection);
     let conn = create_db!(connection);
     drop_table!(conn, NAMESPACE, "contacts");
     conn.finish().unwrap();
@@ -80,6 +84,7 @@ fn it_can_add_a_new_column_to_an_existing_table() {
 
     // Preliminary: create a database with a partial table
     let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
+    dump_capabilities!(connection);
     let conn = create_db!(connection);
     drop_table!(conn, NAMESPACE, "contacts");
     conn.batch_execute(&format!("CREATE SCHEMA IF NOT EXISTS {}", NAMESPACE)).unwrap();
@@ -99,6 +104,7 @@ fn it_can_modify_an_existing_column_on_a_table() {
 
     // Preliminary: create a database with a partial table
     let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
+    dump_capabilities!(connection);
     let conn = create_db!(connection);
     drop_table!(conn, NAMESPACE, "contacts");
     conn.batch_execute(&format!("CREATE SCHEMA IF NOT EXISTS {}", NAMESPACE)).unwrap();
@@ -118,6 +124,7 @@ fn it_can_drop_an_existing_column_on_a_table() {
 
     // Preliminary: create a database with a partial table
     let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
+    dump_capabilities!(connection);
     let conn = create_db!(connection);
     drop_table!(conn, NAMESPACE, "contacts");
     conn.batch_execute(&format!("CREATE SCHEMA IF NOT EXISTS {}", NAMESPACE)).unwrap();
@@ -137,6 +144,7 @@ fn it_can_add_a_new_index_to_an_existing_table() {
 
     // Preliminary: create a database with a table but no indexes
     let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
+    dump_capabilities!(connection);
     let conn = create_db!(connection);
     drop_table!(conn, NAMESPACE, "contacts");
     conn.batch_execute(&format!("CREATE SCHEMA IF NOT EXISTS {}", NAMESPACE)).unwrap();
@@ -156,6 +164,7 @@ fn it_can_modify_an_index_on_a_table() {
 
     // Preliminary: create a database with a table but a broad index
     let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
+    dump_capabilities!(connection);
     let conn = create_db!(connection);
     drop_table!(conn, NAMESPACE, "contacts");
     conn.batch_execute(&format!("CREATE SCHEMA IF NOT EXISTS {}", NAMESPACE)).unwrap();
@@ -176,6 +185,7 @@ fn it_can_drop_an_index_on_a_table() {
 
     // Preliminary: create a database with a table and extra index
     let connection = ConnectionBuilder::new(DB_NAME, "localhost", "postgres").build().unwrap();
+    dump_capabilities!(connection);
     let conn = create_db!(connection);
     drop_table!(conn, NAMESPACE, "contacts");
     conn.batch_execute(&format!("CREATE SCHEMA IF NOT EXISTS {}", NAMESPACE)).unwrap();

--- a/psqlpack/tests/publish.rs
+++ b/psqlpack/tests/publish.rs
@@ -13,7 +13,7 @@ use slog::{Discard, Drain, Logger};
 use spectral::prelude::*;
 
 macro_rules! publish_package {
-    ($namespace:ident, $db_name:ident, $connection:ident, $package:ident) => {{
+    ($db_name:ident, $connection:ident, $package:ident) => {{
         // Use the default publish profile
         let mut publish_profile = PublishProfile::default();
         publish_profile.generation_options.drop_tables = Toggle::Ignore; // We reuse the same database
@@ -52,7 +52,7 @@ fn it_can_create_a_database_that_doesnt_exist() {
 
     // Publish with basic assert
     let package = generate_simple_package!(NAMESPACE);
-    let final_package = publish_package!(NAMESPACE, DB_NAME, connection, package);
+    let final_package = publish_package!(DB_NAME, connection, package);
     assert_simple_package!(final_package, NAMESPACE);
 }
 
@@ -69,7 +69,7 @@ fn it_can_add_a_new_table_to_an_existing_database() {
 
     // Publish with basic assert
     let package = generate_simple_package!(NAMESPACE);
-    let final_package = publish_package!(NAMESPACE, DB_NAME, connection, package);
+    let final_package = publish_package!(DB_NAME, connection, package);
     assert_simple_package!(final_package, NAMESPACE);
 }
 
@@ -88,7 +88,7 @@ fn it_can_add_a_new_column_to_an_existing_table() {
 
     // Publish with basic assert
     let package = generate_simple_package!(NAMESPACE);
-    let final_package = publish_package!(NAMESPACE, DB_NAME, connection, package);
+    let final_package = publish_package!(DB_NAME, connection, package);
     assert_simple_package!(final_package, NAMESPACE);
 }
 
@@ -107,7 +107,7 @@ fn it_can_modify_an_existing_column_on_a_table() {
 
     // Publish with basic assert
     let package = generate_simple_package!(NAMESPACE);
-    let final_package = publish_package!(NAMESPACE, DB_NAME, connection, package);
+    let final_package = publish_package!(DB_NAME, connection, package);
     assert_simple_package!(final_package, NAMESPACE);
 }
 
@@ -126,7 +126,7 @@ fn it_can_drop_an_existing_column_on_a_table() {
 
     // Publish with basic assert
     let package = generate_simple_package!(NAMESPACE);
-    let final_package = publish_package!(NAMESPACE, DB_NAME, connection, package);
+    let final_package = publish_package!(DB_NAME, connection, package);
     assert_simple_package!(final_package, NAMESPACE);
 }
 
@@ -145,7 +145,7 @@ fn it_can_add_a_new_index_to_an_existing_table() {
 
     // Publish with basic assert
     let package = generate_simple_package!(NAMESPACE);
-    let final_package = publish_package!(NAMESPACE, DB_NAME, connection, package);
+    let final_package = publish_package!(DB_NAME, connection, package);
     assert_simple_package!(final_package, NAMESPACE);
 }
 
@@ -165,7 +165,7 @@ fn it_can_modify_an_index_on_a_table() {
 
     // Publish with basic assert
     let package = generate_simple_package!(NAMESPACE);
-    let final_package = publish_package!(NAMESPACE, DB_NAME, connection, package);
+    let final_package = publish_package!(DB_NAME, connection, package);
     assert_simple_package!(final_package, NAMESPACE);
 }
 
@@ -186,6 +186,6 @@ fn it_can_drop_an_index_on_a_table() {
 
     // Publish with basic assert
     let package = generate_simple_package!(NAMESPACE);
-    let final_package = publish_package!(NAMESPACE, DB_NAME, connection, package);
+    let final_package = publish_package!(DB_NAME, connection, package);
     assert_simple_package!(final_package, NAMESPACE);
 }

--- a/samples/complex/complex.psqlproj
+++ b/samples/complex/complex.psqlproj
@@ -10,9 +10,12 @@
         "scripts/seed/data.table_coefficients.sql",
         "scripts/seed/data.table_versions.sql",
         "scripts/seed/data.taxes.sql",
-        "scripts/seed/geo.states.sql",
         "scripts/seed/reference_data.countries.sql",
         "scripts/seed/reference_data.states.sql"
+    ],
+    "fileExcludeGlobs": [
+        "**/geo/**/*.sql",
+        "**/geo.*"
     ],
     "extensions": [
         { "name": "postgis" },

--- a/samples/complex/complex.psqlproj
+++ b/samples/complex/complex.psqlproj
@@ -15,9 +15,9 @@
         "scripts/seed/reference_data.states.sql"
     ],
     "extensions": [
-        "postgis",
-        "postgis_topology",
-        "fuzzystrmatch",
-        "postgis_tiger_geocoder"
+        { "name": "postgis" },
+        { "name": "postgis_topology" },
+        { "name": "fuzzystrmatch" },
+        { "name": "postgis_tiger_geocoder" }
     ]
 }

--- a/samples/complex/local.publish
+++ b/samples/complex/local.publish
@@ -7,6 +7,7 @@
     "dropTables": "Error",
     "dropColumns": "Error",
     "dropPrimaryKeyConstraints": "Error",
-    "dropForeignKeyConstraints": "Allow"
+    "dropForeignKeyConstraints": "Allow",
+    "dropIndexes": "Ignore"
   }
 }

--- a/samples/complex/reference_data/tables/states.sql
+++ b/samples/complex/reference_data/tables/states.sql
@@ -9,8 +9,8 @@ CREATE TABLE reference_data.states
   CONSTRAINT pk_reference_data_states PRIMARY KEY (id),
   CONSTRAINT fk_reference_data_states__country_id FOREIGN KEY (country_id)
       REFERENCES reference_data.countries (id) MATCH SIMPLE
-      ON UPDATE NO ACTION ON DELETE NO ACTION,
-  CONSTRAINT fk_reference_data_states__gid FOREIGN KEY (gid)
+      ON UPDATE NO ACTION ON DELETE NO ACTION
+  /*,CONSTRAINT fk_reference_data_states__gid FOREIGN KEY (gid)
       REFERENCES geo.states (gid) MATCH SIMPLE
-      ON UPDATE NO ACTION ON DELETE NO ACTION      
+      ON UPDATE NO ACTION ON DELETE NO ACTION*/   
 )

--- a/samples/psqlpack.sh
+++ b/samples/psqlpack.sh
@@ -44,6 +44,7 @@ case $1 in
         ;;        
     unpack)
         action="Unpacking psqlpack for '$db'"
+        rm -rf out/$db
         unzip out/$db.psqlpack -d out/$db
         ;;
     *)


### PR DESCRIPTION
This is the first step towards proper extension support in `psqlpack` (see #69). This adds in the ability to "create" extensions as well as appropriately "update" them if desired. It also starts using "capabilities" so that we can eventually branch between server versions.
 