### PR TITLE
Support TOML format for publish profiles and project files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,6 +1076,7 @@ dependencies = [
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-stdlog 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spectral 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1631,6 +1632,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typenum"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +1929,7 @@ dependencies = [
 "checksum tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1bef565a52394086ecac0a6fa3b8ace4cb3a138ee1d96bd2b93283b56824e3"
 "checksum tokio-postgres 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c03cb0c66092269a9b280e9e4956cb23ce00b8a6b1b393f7700f7732ac4bf133"
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
+"checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"

--- a/psqlpack/Cargo.toml
+++ b/psqlpack/Cargo.toml
@@ -14,16 +14,17 @@ error-chain = "0.12"
 glob = "0.3"
 lazy_static = "1.4"
 lalrpop-util = "0.17"
-slog = { version = "2.5", features = ["max_level_trace", "release_max_level_trace"] }
-slog-stdlog = "4.0"
+petgraph = "0.5"
 postgres = { version = "0.17", features = ["with-serde_json-1"] }
 regex = "1.0"
 rust_decimal = "1.1"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+slog = { version = "2.5", features = ["max_level_trace", "release_max_level_trace"] }
+slog-stdlog = "4.0"
+toml = "0.5"
 zip = "0.5"
-petgraph = "0.5"
 
 [build-dependencies]
 lalrpop = "0.17"

--- a/psqlpack/src/errors.rs
+++ b/psqlpack/src/errors.rs
@@ -22,9 +22,9 @@ error_chain! {
             description("Couldn't read project file")
             display("Couldn't read project file: {}", path.as_path().display())
         }
-        ProjectParseError(path: PathBuf) {
+        ProjectParseError(message: String) {
             description("Couldn't parse project file")
-            display("Couldn't parse project file: {}", path.as_path().display())
+            display("Couldn't parse project file: {}", message)
         }
         InvalidScriptPath(path: String) {
             description("Invalid script path in project file")
@@ -34,9 +34,9 @@ error_chain! {
             description("Couldn't read publish profile file")
             display("Couldn't read publish profile file: {}", path.as_path().display())
         }
-        PublishProfileParseError(path: PathBuf) {
-            description("Couldn't parse publish profile file")
-            display("Couldn't parse publish profile file: {}", path.as_path().display())
+        PublishProfileParseError(message: String) {
+            description("Couldn't parse publish profile")
+            display("Couldn't parse publish profile: {}", message)
         }
         PackageCreationError(message: String) {
             description("Failed to create package")

--- a/psqlpack/src/model/profiles.rs
+++ b/psqlpack/src/model/profiles.rs
@@ -5,6 +5,7 @@
 
 use std::default::Default;
 use std::fs::File;
+use std::io::{BufReader, Read};
 use std::path::Path;
 
 use serde_json;
@@ -16,11 +17,11 @@ use crate::semver::Semver;
 #[derive(Deserialize, Serialize)]
 pub struct PublishProfile {
     pub version: Semver,
-    #[serde(rename = "generationOptions")]
+    #[serde(alias = "generationOptions")]
     pub generation_options: GenerationOptions,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
 pub enum Toggle {
     Allow,
     Ignore,
@@ -28,14 +29,10 @@ pub enum Toggle {
 }
 
 impl Toggle {
-    fn allow() -> Toggle {
-        Toggle::Allow
-    }
-
+    fn allow() -> Toggle { Toggle::Allow }
     fn ignore() -> Toggle {
         Toggle::Ignore
     }
-
     fn error() -> Toggle {
         Toggle::Error
     }
@@ -51,46 +48,46 @@ impl Bool {
 #[derive(Deserialize, Serialize)]
 pub struct GenerationOptions {
     /// If set to true, the database will always be recereated
-    #[serde(rename = "alwaysRecreateDatabase")]
+    #[serde(alias = "alwaysRecreateDatabase")]
     pub always_recreate_database: bool,
 
     /// Enum values are typically unsafe to delete. If set to Allow, psqlpack will attempt to delete.
     /// Default: Error
-    #[serde(rename = "dropEnumValues", default = "Toggle::error")]
+    #[serde(alias = "dropEnumValues", default = "Toggle::error")]
     pub drop_enum_values: Toggle,
     /// Tables may have data in them which may not be intended to be deleted. If set to Allow, psqlpack will drop the table.
     /// Default: Error
-    #[serde(rename = "dropTables", default = "Toggle::error")]
+    #[serde(alias = "dropTables", default = "Toggle::error")]
     pub drop_tables: Toggle,
     /// Columns may have data in them which may not be intended to be deleted. If set to Allow, psqlpack will drop the column.
     /// Default: Error
-    #[serde(rename = "dropColumns", default = "Toggle::error")]
+    #[serde(alias = "dropColumns", default = "Toggle::error")]
     pub drop_columns: Toggle,
     /// Primary Keys define how a table is looked up on disk. If set to Allow, psqlpack will drop the primary key.
     /// Default: Error
-    #[serde(rename = "dropPrimaryKeyConstraints", default = "Toggle::error")]
+    #[serde(alias = "dropPrimaryKeyConstraints", default = "Toggle::error")]
     pub drop_primary_key_constraints: Toggle,
     /// Foreign Keys define a constraint to another table. If set to Allow, psqlpack will drop the foreign key.
     /// Default: Allow
-    #[serde(rename = "dropForeignKeyConstraints", default = "Toggle::allow")]
+    #[serde(alias = "dropForeignKeyConstraints", default = "Toggle::allow")]
     pub drop_foreign_key_constraints: Toggle,
     /// Functions may not be intended to be deleted. If set to Allow, psqlpack will drop the function.
     /// Default: Error
-    #[serde(rename = "dropFunctions", default = "Toggle::error")]
+    #[serde(alias = "dropFunctions", default = "Toggle::error")]
     pub drop_functions: Toggle,
     /// Indexes may not be intended to be deleted. If set to Allow, psqlpack will drop the index.
     /// Default: Allow
-    #[serde(rename = "dropIndexes", default = "Toggle::allow")]
+    #[serde(alias = "dropIndexes", default = "Toggle::allow")]
     pub drop_indexes: Toggle,
 
     /// Extensions may not be intended to be upgraded automatically. If set to Allow, psqlpack will upgrade the extension as necessary.
     /// Default: Ignore
-    #[serde(rename = "upgradeExtensions", default = "Toggle::ignore")]
+    #[serde(alias = "upgradeExtensions", default = "Toggle::ignore")]
     pub upgrade_extensions: Toggle,
 
     /// Forces index changes to be made concurrently to avoid locking on table writes.
     /// Default: true
-    #[serde(rename = "forceConcurrentIndexes", default = "Bool::t")]
+    #[serde(alias = "forceConcurrentIndexes", default = "Bool::t")]
     pub force_concurrent_indexes: bool,
 }
 
@@ -121,8 +118,96 @@ impl PublishProfile {
     pub fn from_path(profile_path: &Path) -> PsqlpackResult<PublishProfile> {
         File::open(profile_path)
             .chain_err(|| PublishProfileReadError(profile_path.to_path_buf()))
-            .and_then(|file| {
-                serde_json::from_reader(file).chain_err(|| PublishProfileParseError(profile_path.to_path_buf()))
-            })
+            .and_then(|file| Self::from_reader(file))
+    }
+
+    fn from_reader<R>(reader: R) -> PsqlpackResult<PublishProfile>
+        where R: Read {
+
+        let mut buffered_reader = BufReader::new(reader);
+        let mut contents = String::new();
+        if buffered_reader.read_to_string(&mut contents)
+            .chain_err(|| PublishProfileParseError("Failed to read contents".into()))? == 0 {
+            bail!(PublishProfileParseError("Data was empty".into()))
+        }
+
+        let trimmed = contents.trim_start();
+        if trimmed.starts_with('{') {
+            serde_json::from_str(&contents).chain_err(|| PublishProfileParseError("Failed to read JSON".into()))
+        } else {
+            toml::from_str(&contents).chain_err(|| PublishProfileParseError("Failed to read TOML".into()))
+        }
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{PublishProfile, Semver};
+    use crate::model::Toggle;
+    use spectral::prelude::*;
+
+    #[test]
+    fn it_can_add_read_a_publish_profile_in_json_format() {
+        const DATA: &str = r#"
+            {
+              "version": "1.0",
+              "generationOptions": {
+                "alwaysRecreateDatabase": false,
+                "dropEnumValues": "Error",
+                "dropFunctions": "Error",
+                "dropTables": "Error",
+                "dropColumns": "Error",
+                "dropPrimaryKeyConstraints": "Error",
+                "dropForeignKeyConstraints": "Allow",
+                "dropIndexes": "Ignore",
+                "forceConcurrentIndexes": false
+              }
+            }
+        "#;
+        let publish_profile = PublishProfile::from_reader(DATA.as_bytes());
+        let publish_profile = publish_profile.unwrap();
+        assert_that!(publish_profile.version).is_equal_to(Semver::new(1, 0, None));
+        let options = publish_profile.generation_options;
+        assert_that!(options.always_recreate_database).is_false();
+        assert_that!(options.drop_enum_values).is_equal_to(Toggle::Error);
+        assert_that!(options.drop_functions).is_equal_to(Toggle::Error);
+        assert_that!(options.drop_tables).is_equal_to(Toggle::Error);
+        assert_that!(options.drop_columns).is_equal_to(Toggle::Error);
+        assert_that!(options.drop_primary_key_constraints).is_equal_to(Toggle::Error);
+        assert_that!(options.drop_foreign_key_constraints).is_equal_to(Toggle::Allow);
+        assert_that!(options.drop_indexes).is_equal_to(Toggle::Ignore);
+        assert_that!(options.force_concurrent_indexes).is_false();
+    }
+
+    #[test]
+    fn it_can_add_read_a_publish_profile_in_toml_format() {
+        const DATA: &str = r#"
+            version = "1.0"
+
+            [generationOptions]
+            always_recreate_database = false
+            drop_enum_values = "Error"
+            drop_functions = "Error"
+            drop_tables = "Error"
+            drop_columns = "Error"
+            drop_primary_key_constraints = "Error"
+            drop_foreign_key_constraints = "Allow"
+            drop_indexes = "Ignore"
+            force_concurrent_indexes = false
+        "#;
+        let publish_profile = PublishProfile::from_reader(DATA.as_bytes());
+        let publish_profile = publish_profile.unwrap();
+        assert_that!(publish_profile.version).is_equal_to(Semver::new(1, 0, None));
+        let options = publish_profile.generation_options;
+        assert_that!(options.always_recreate_database).is_false();
+        assert_that!(options.drop_enum_values).is_equal_to(Toggle::Error);
+        assert_that!(options.drop_functions).is_equal_to(Toggle::Error);
+        assert_that!(options.drop_tables).is_equal_to(Toggle::Error);
+        assert_that!(options.drop_columns).is_equal_to(Toggle::Error);
+        assert_that!(options.drop_primary_key_constraints).is_equal_to(Toggle::Error);
+        assert_that!(options.drop_foreign_key_constraints).is_equal_to(Toggle::Allow);
+        assert_that!(options.drop_indexes).is_equal_to(Toggle::Ignore);
+        assert_that!(options.force_concurrent_indexes).is_false();
     }
 }

--- a/psqlpack/src/model/profiles.rs
+++ b/psqlpack/src/model/profiles.rs
@@ -29,7 +29,9 @@ pub enum Toggle {
 }
 
 impl Toggle {
-    fn allow() -> Toggle { Toggle::Allow }
+    fn allow() -> Toggle {
+        Toggle::Allow
+    }
     fn ignore() -> Toggle {
         Toggle::Ignore
     }
@@ -122,12 +124,16 @@ impl PublishProfile {
     }
 
     fn from_reader<R>(reader: R) -> PsqlpackResult<PublishProfile>
-        where R: Read {
-
+    where
+        R: Read,
+    {
         let mut buffered_reader = BufReader::new(reader);
         let mut contents = String::new();
-        if buffered_reader.read_to_string(&mut contents)
-            .chain_err(|| PublishProfileParseError("Failed to read contents".into()))? == 0 {
+        if buffered_reader
+            .read_to_string(&mut contents)
+            .chain_err(|| PublishProfileParseError("Failed to read contents".into()))?
+            == 0
+        {
             bail!(PublishProfileParseError("Data was empty".into()))
         }
 
@@ -138,13 +144,12 @@ impl PublishProfile {
             toml::from_str(&contents).chain_err(|| PublishProfileParseError("Failed to read TOML".into()))
         }
     }
-
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{PublishProfile, Semver};
     use crate::model::Toggle;
+    use crate::{PublishProfile, Semver};
     use spectral::prelude::*;
 
     #[test]

--- a/psqlpack/src/model/project.rs
+++ b/psqlpack/src/model/project.rs
@@ -1,7 +1,7 @@
 use std::default::Default;
 use std::fmt;
 use std::fs::File;
-use std::io::Read;
+use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 
 use glob::glob;
@@ -39,15 +39,15 @@ pub struct Project {
     pub version: Semver,
 
     /// The default schema for the database. Typically `public`
-    #[serde(rename = "defaultSchema")]
+    #[serde(alias = "defaultSchema")]
     pub default_schema: String,
 
     /// An array of scripts to run before anything is deployed
-    #[serde(rename = "preDeployScripts")]
+    #[serde(alias = "preDeployScripts")]
     pub pre_deploy_scripts: Vec<String>,
 
     /// An array of scripts to run after everything has been deployed
-    #[serde(rename = "postDeployScripts")]
+    #[serde(alias = "postDeployScripts")]
     pub post_deploy_scripts: Vec<String>,
 
     /// An array of extensions to include within this project
@@ -55,15 +55,15 @@ pub struct Project {
     pub extensions: Option<Vec<Dependency>>,
 
     /// An array of globs representing files/folders to be included within your project. Defaults to `["**/*.sql"]`.
-    #[serde(rename = "fileIncludeGlobs", skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "fileIncludeGlobs", alias = "file_include_globs", skip_serializing_if = "Option::is_none")]
     pub include_globs: Option<Vec<String>>,
 
     /// An array of globs representing files/folders to be excluded within your project.
-    #[serde(rename = "fileExcludeGlobs", skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "fileExcludeGlobs", alias = "file_exclude_globs", skip_serializing_if = "Option::is_none")]
     pub exclude_globs: Option<Vec<String>>,
 
     /// An array of search paths to look in outside of the standard paths (./lib, ~/.psqlpack/lib).
-    #[serde(rename = "referenceSearchPaths", skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "referenceSearchPaths", skip_serializing_if = "Option::is_none")]
     pub reference_search_paths: Option<Vec<String>>,
 }
 
@@ -108,7 +108,7 @@ impl Project {
             .chain_err(|| ProjectReadError(project_file_path.to_path_buf()))
             .and_then(|file| {
                 trace!(log, "Parsing project file");
-                serde_json::from_reader(file).chain_err(|| ProjectParseError(project_file_path.to_path_buf()))
+                Self::from_reader(file)
             })
             .and_then(|mut project: Project| {
                 project.project_file_path = Some(project_file_path.to_path_buf());
@@ -117,6 +117,23 @@ impl Project {
                 }
                 Ok(project)
             })
+    }
+
+    fn from_reader<R>(reader: R) -> PsqlpackResult<Project>
+        where R: Read {
+        let mut buffered_reader = BufReader::new(reader);
+        let mut contents = String::new();
+        if buffered_reader.read_to_string(&mut contents)
+            .chain_err(|| ProjectParseError("Failed to read contents".into()))? == 0 {
+            bail!(ProjectParseError("Data was empty".into()))
+        }
+
+        let trimmed = contents.trim_start();
+        if trimmed.starts_with('{') {
+            serde_json::from_str(&contents).chain_err(|| ProjectParseError("Failed to read JSON".into()))
+        } else {
+            toml::from_str(&contents).chain_err(|| ProjectParseError("Failed to read TOML".into()))
+        }
     }
 
     pub fn build_package(&self, log: &Logger) -> PsqlpackResult<Package> {
@@ -297,7 +314,8 @@ impl Project {
 #[cfg(test)]
 mod tests {
 
-    use super::Project;
+    use crate::model::project::Project;
+    use crate::{Semver, Dependency};
     use spectral::prelude::*;
     use std::path::Path;
 
@@ -398,5 +416,103 @@ mod tests {
         let result = result.unwrap();
         let result: Vec<&str> = result.iter().map(|x| x.to_str().unwrap()).collect();
         assert_that!(result).contains_all_of(&vec![&"../samples/simple/public/tables/public.organisation.sql"]);
+    }
+
+    #[test]
+    fn it_can_add_read_a_project_in_json_format() {
+        const DATA: &str = r#"
+            {
+                "version": "1.0",
+                "defaultSchema": "public",
+                "preDeployScripts": [
+                    "scripts/pre-deploy/drop-something.sql"
+                ],
+                "postDeployScripts": [
+                    "scripts/seed/seed1.sql",
+                    "scripts/seed/seed2.sql"
+                ],
+                "fileExcludeGlobs": [
+                    "**/ex/**/*.sql",
+                    "**/ex.*"
+                ],
+                "extensions": [
+                    { "name": "postgis" },
+                    { "name": "postgis_topology" },
+                    { "name": "postgis_tiger_geocoder" }
+                ]
+            }
+        "#;
+        let project = Project::from_reader(DATA.as_bytes());
+        let project = project.unwrap();
+        assert_that!(project.version).is_equal_to(Semver::new(1, 0, None));
+        assert_that!(project.default_schema).is_equal_to("public".to_owned());
+
+        assert_that!(project.pre_deploy_scripts).has_length(1);
+        assert_that!(project.pre_deploy_scripts[0]).is_equal_to("scripts/pre-deploy/drop-something.sql".to_owned());
+
+        assert_that!(project.post_deploy_scripts).has_length(2);
+        assert_that!(project.post_deploy_scripts[0]).is_equal_to("scripts/seed/seed1.sql".to_owned());
+        assert_that!(project.post_deploy_scripts[1]).is_equal_to("scripts/seed/seed2.sql".to_owned());
+
+        assert_that!(project.exclude_globs).is_some();
+        let exclude_globs = project.exclude_globs.unwrap();
+        assert_that!(exclude_globs).has_length(2);
+        assert_that!(exclude_globs[0]).is_equal_to("**/ex/**/*.sql".to_owned());
+        assert_that!(exclude_globs[1]).is_equal_to("**/ex.*".to_owned());
+
+        assert_that!(project.extensions).is_some();
+        let extensions = project.extensions.unwrap();
+        assert_that!(extensions).has_length(3);
+        assert_that!(extensions[0]).is_equal_to(Dependency { name: "postgis".into(), version: None });
+        assert_that!(extensions[1]).is_equal_to(Dependency { name: "postgis_topology".into(), version: None });
+        assert_that!(extensions[2]).is_equal_to(Dependency { name: "postgis_tiger_geocoder".into(), version: None });
+    }
+
+    #[test]
+    fn it_can_add_read_a_project_in_toml_format() {
+        const DATA: &str = r#"
+            version = "1.0"
+            default_schema = "public"
+            pre_deploy_scripts = [
+                "scripts/pre-deploy/drop-something.sql"
+            ]
+            post_deploy_scripts = [
+                "scripts/seed/seed1.sql",
+                "scripts/seed/seed2.sql"
+            ]
+            file_exclude_globs = [
+                "**/ex/**/*.sql",
+                "**/ex.*"
+            ]
+            extensions = [
+                { name = "postgis" },
+                { name = "postgis_topology" },
+                { name = "postgis_tiger_geocoder" }
+            ]
+        "#;
+        let project = Project::from_reader(DATA.as_bytes());
+        let project = project.unwrap();
+        assert_that!(project.version).is_equal_to(Semver::new(1, 0, None));
+        assert_that!(project.default_schema).is_equal_to("public".to_owned());
+
+        assert_that!(project.pre_deploy_scripts).has_length(1);
+        assert_that!(project.pre_deploy_scripts[0]).is_equal_to("scripts/pre-deploy/drop-something.sql".to_owned());
+
+        assert_that!(project.post_deploy_scripts).has_length(2);
+        assert_that!(project.post_deploy_scripts[0]).is_equal_to("scripts/seed/seed1.sql".to_owned());
+        assert_that!(project.post_deploy_scripts[1]).is_equal_to("scripts/seed/seed2.sql".to_owned());
+
+        assert_that!(project.exclude_globs).is_some();
+        let exclude_globs = project.exclude_globs.unwrap();
+        assert_that!(exclude_globs).has_length(2);
+        assert_that!(exclude_globs[0]).is_equal_to("**/ex/**/*.sql".to_owned());
+        assert_that!(exclude_globs[1]).is_equal_to("**/ex.*".to_owned());
+
+        assert_that!(project.extensions).is_some();
+        let extensions = project.extensions.unwrap();
+        assert_that!(extensions).has_length(3);
+        assert_that!(extensions[0]).is_equal_to(Dependency { name: "postgis".into(), version: None });
+        assert_that!(extensions[1]).is_equal_to(Dependency { name: "postgis_topology".into(), version: None });
+        assert_that!(extensions[2]).is_equal_to(Dependency { name: "postgis_tiger_geocoder".into(), version: None });
     }
 }

--- a/psqlpack/src/model/project.rs
+++ b/psqlpack/src/model/project.rs
@@ -55,11 +55,19 @@ pub struct Project {
     pub extensions: Option<Vec<Dependency>>,
 
     /// An array of globs representing files/folders to be included within your project. Defaults to `["**/*.sql"]`.
-    #[serde(alias = "fileIncludeGlobs", alias = "file_include_globs", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        alias = "fileIncludeGlobs",
+        alias = "file_include_globs",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub include_globs: Option<Vec<String>>,
 
     /// An array of globs representing files/folders to be excluded within your project.
-    #[serde(alias = "fileExcludeGlobs", alias = "file_exclude_globs", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        alias = "fileExcludeGlobs",
+        alias = "file_exclude_globs",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub exclude_globs: Option<Vec<String>>,
 
     /// An array of search paths to look in outside of the standard paths (./lib, ~/.psqlpack/lib).
@@ -120,11 +128,16 @@ impl Project {
     }
 
     fn from_reader<R>(reader: R) -> PsqlpackResult<Project>
-        where R: Read {
+    where
+        R: Read,
+    {
         let mut buffered_reader = BufReader::new(reader);
         let mut contents = String::new();
-        if buffered_reader.read_to_string(&mut contents)
-            .chain_err(|| ProjectParseError("Failed to read contents".into()))? == 0 {
+        if buffered_reader
+            .read_to_string(&mut contents)
+            .chain_err(|| ProjectParseError("Failed to read contents".into()))?
+            == 0
+        {
             bail!(ProjectParseError("Data was empty".into()))
         }
 
@@ -315,7 +328,7 @@ impl Project {
 mod tests {
 
     use crate::model::project::Project;
-    use crate::{Semver, Dependency};
+    use crate::{Dependency, Semver};
     use spectral::prelude::*;
     use std::path::Path;
 
@@ -463,9 +476,18 @@ mod tests {
         assert_that!(project.extensions).is_some();
         let extensions = project.extensions.unwrap();
         assert_that!(extensions).has_length(3);
-        assert_that!(extensions[0]).is_equal_to(Dependency { name: "postgis".into(), version: None });
-        assert_that!(extensions[1]).is_equal_to(Dependency { name: "postgis_topology".into(), version: None });
-        assert_that!(extensions[2]).is_equal_to(Dependency { name: "postgis_tiger_geocoder".into(), version: None });
+        assert_that!(extensions[0]).is_equal_to(Dependency {
+            name: "postgis".into(),
+            version: None,
+        });
+        assert_that!(extensions[1]).is_equal_to(Dependency {
+            name: "postgis_topology".into(),
+            version: None,
+        });
+        assert_that!(extensions[2]).is_equal_to(Dependency {
+            name: "postgis_tiger_geocoder".into(),
+            version: None,
+        });
     }
 
     #[test]
@@ -511,8 +533,17 @@ mod tests {
         assert_that!(project.extensions).is_some();
         let extensions = project.extensions.unwrap();
         assert_that!(extensions).has_length(3);
-        assert_that!(extensions[0]).is_equal_to(Dependency { name: "postgis".into(), version: None });
-        assert_that!(extensions[1]).is_equal_to(Dependency { name: "postgis_topology".into(), version: None });
-        assert_that!(extensions[2]).is_equal_to(Dependency { name: "postgis_tiger_geocoder".into(), version: None });
+        assert_that!(extensions[0]).is_equal_to(Dependency {
+            name: "postgis".into(),
+            version: None,
+        });
+        assert_that!(extensions[1]).is_equal_to(Dependency {
+            name: "postgis_topology".into(),
+            version: None,
+        });
+        assert_that!(extensions[2]).is_equal_to(Dependency {
+            name: "postgis_tiger_geocoder".into(),
+            version: None,
+        });
     }
 }

--- a/samples/complex/complex.psqlproj
+++ b/samples/complex/complex.psqlproj
@@ -1,26 +1,24 @@
-{
-    "version": "1.0",
-    "defaultSchema": "public",
-    "preDeployScripts": [],
-    "postDeployScripts": [
-        "scripts/seed/data.constant_values.sql",
-        "scripts/seed/data.constant_versions.sql",
-        "scripts/seed/data.idents.sql",
-        "scripts/seed/data.parameters.sql",
-        "scripts/seed/data.table_coefficients.sql",
-        "scripts/seed/data.table_versions.sql",
-        "scripts/seed/data.taxes.sql",
-        "scripts/seed/reference_data.countries.sql",
-        "scripts/seed/reference_data.states.sql"
-    ],
-    "fileExcludeGlobs": [
-        "**/geo/**/*.sql",
-        "**/geo.*"
-    ],
-    "extensions": [
-        { "name": "postgis" },
-        { "name": "postgis_topology" },
-        { "name": "fuzzystrmatch" },
-        { "name": "postgis_tiger_geocoder" }
-    ]
-}
+version = "1.0"
+default_schema = "public"
+pre_deploy_scripts = []
+post_deploy_scripts = [
+    "scripts/seed/data.constant_values.sql",
+    "scripts/seed/data.constant_versions.sql",
+    "scripts/seed/data.idents.sql",
+    "scripts/seed/data.parameters.sql",
+    "scripts/seed/data.table_coefficients.sql",
+    "scripts/seed/data.table_versions.sql",
+    "scripts/seed/data.taxes.sql",
+    "scripts/seed/reference_data.countries.sql",
+    "scripts/seed/reference_data.states.sql"
+]
+file_exclude_globs = [
+    "**/geo/**/*.sql",
+    "**/geo.*"
+]
+extensions = [
+    { name = "postgis" },
+    { name = "postgis_topology" },
+    { name = "fuzzystrmatch" },
+    { name = "postgis_tiger_geocoder" }
+]

--- a/samples/complex/local.publish
+++ b/samples/complex/local.publish
@@ -1,13 +1,11 @@
-{
-  "version": "1.0",
-  "generationOptions": {
-    "alwaysRecreateDatabase": false,
-    "dropEnumValues": "Error",
-    "dropFunctions": "Error",
-    "dropTables": "Error",
-    "dropColumns": "Error",
-    "dropPrimaryKeyConstraints": "Error",
-    "dropForeignKeyConstraints": "Allow",
-    "dropIndexes": "Ignore"
-  }
-}
+version = "1.0"
+
+[generationOptions]
+always_recreate_database = false
+drop_enum_values = "Error"
+drop_functions = "Error"
+drop_tables = "Error"
+drop_columns = "Error"
+drop_primary_key_constraints = "Error"
+drop_foreign_key_constraints = "Allow"
+drop_indexes = "Ignore"

--- a/samples/trivial/local.publish
+++ b/samples/trivial/local.publish
@@ -1,12 +1,11 @@
-{
-  "version": "1.0",
-  "generationOptions": {
-    "alwaysRecreateDatabase": false,
-    "dropEnumValues": "Error",
-    "dropFunctions": "Error",
-    "dropTables": "Error",
-    "dropColumns": "Error",
-    "dropPrimaryKeyConstraints": "Error",
-    "dropForeignKeyConstraints": "Allow"
-  }
-}
+version = "1.0"
+
+[generationOptions]
+always_recreate_database = false
+drop_enum_values = "Error"
+drop_functions = "Error"
+drop_tables = "Error"
+drop_columns = "Error"
+drop_primary_key_constraints = "Error"
+drop_foreign_key_constraints = "Allow"
+drop_indexes = "Ignore"

--- a/samples/trivial/trivial.psqlproj
+++ b/samples/trivial/trivial.psqlproj
@@ -1,6 +1,4 @@
-{
-    "version": "1.0",
-    "defaultSchema": "public",
-    "preDeployScripts": [],
-    "postDeployScripts": []
-}
+version = "1.0"
+default_schema = "public"
+pre_deploy_scripts = []
+post_deploy_scripts = []


### PR DESCRIPTION
Fixes #123 
Adds in TOML support for both `.publish` and `.psqlproj` files.