### PR TITLE
Remove spectral from dev dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
+checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 
 [[package]]
 name = "arrayvec"
@@ -70,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -125,9 +134,9 @@ checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
 name = "bit-set"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
  "bit-vec",
 ]
@@ -154,6 +163,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,9 +176,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "bzip2"
@@ -203,15 +218,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "3f725f340c3854e3cb3ab736dc21f0cca183303acea3b3ffec30f141503ac8eb"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time 0.1.44",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -247,6 +264,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -282,9 +305,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ccfd8c0ee4cce11e45b3fd6f9d5e69e0cc62912aa6a0cb1bf4617b0eba5a12f"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -396,12 +419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -513,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "glob"
@@ -525,9 +542,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -545,6 +562,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf7d67cf4a22adc5be66e75ebdf769b3f2ea032041437a7061f97a63dad4b"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
 ]
 
 [[package]]
@@ -568,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jobserver"
@@ -579,6 +609,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -621,9 +660,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
 name = "lock_api"
@@ -687,42 +726,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
-name = "num"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
-dependencies = [
- "num-integer",
- "num-traits",
- "rand 0.4.6",
- "rustc-serialize",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
-dependencies = [
- "num-traits",
- "rustc-serialize",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,29 +733,6 @@ checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
- "rustc-serialize",
 ]
 
 [[package]]
@@ -824,7 +804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
 dependencies = [
  "base64ct",
- "rand_core 0.6.3",
+ "rand_core",
  "subtle",
 ]
 
@@ -925,7 +905,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.8.5",
+ "rand",
  "sha2",
  "stringprep",
 ]
@@ -957,9 +937,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
@@ -983,7 +963,6 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-stdlog",
- "spectral",
  "toml",
  "zip",
 ]
@@ -1000,24 +979,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
 ]
 
 [[package]]
@@ -1028,7 +994,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1038,23 +1004,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1066,19 +1017,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
@@ -1113,9 +1055,9 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rust_decimal"
-version = "1.25.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a3bb58e85333f1ab191bf979104b586ebd77475bc6681882825f4532dfe87c"
+checksum = "ee9164faf726e4f3ece4978b25ca877ddc6802fa77f38cdccb32c7f805ecd70c"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -1129,22 +1071,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-
-[[package]]
 name = "rustversion"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "scopeguard"
@@ -1154,18 +1090,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.139"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.139"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1174,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa",
  "ryu",
@@ -1213,9 +1149,12 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "slog"
@@ -1255,7 +1194,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.11",
+ "time 0.3.13",
 ]
 
 [[package]]
@@ -1272,15 +1211,6 @@ checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "spectral"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
-dependencies = [
- "num",
 ]
 
 [[package]]
@@ -1320,9 +1250,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1362,18 +1292,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1402,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
+checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
  "itoa",
  "libc",
@@ -1444,10 +1374,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -1506,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -1517,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
 ]
@@ -1538,9 +1469,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-normalization"
@@ -1586,6 +1517,60 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "winapi"
@@ -1668,7 +1653,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time 0.3.11",
+ "time 0.3.13",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
@@ -211,7 +211,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.43",
+ "time 0.1.44",
  "winapi",
 ]
 
@@ -266,12 +266,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -282,9 +282,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "2ccfd8c0ee4cce11e45b3fd6f9d5e69e0cc62912aa6a0cb1bf4617b0eba5a12f"
 dependencies = [
  "generic-array",
  "typenum",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "diff"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "ena"
@@ -381,9 +381,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -502,13 +502,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -525,9 +525,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
 
 [[package]]
 name = "hermit-abi"
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -670,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
@@ -775,18 +775,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.28.4"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
@@ -957,9 +957,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
@@ -1000,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -1096,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1107,15 +1107,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rust_decimal"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ee7337df68898256ad0d4af4aad178210d9e44d2ff900ce44064a97cd86530"
+checksum = "34a3bb58e85333f1ab191bf979104b586ebd77475bc6681882825f4532dfe87c"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -1136,9 +1136,9 @@ checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustversion"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
 
 [[package]]
 name = "ryu"
@@ -1154,18 +1154,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1174,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa",
  "ryu",
@@ -1255,14 +1255,14 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.9",
+ "time 0.3.11",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
@@ -1320,9 +1320,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1391,19 +1391,20 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
  "itoa",
  "libc",
@@ -1505,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -1516,11 +1517,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -1537,15 +1538,15 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]
@@ -1576,9 +1577,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -1667,7 +1668,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time 0.3.9",
+ "time 0.3.11",
  "zstd",
 ]
 

--- a/psqlpack/Cargo.toml
+++ b/psqlpack/Cargo.toml
@@ -28,8 +28,5 @@ zip = "0.6"
 [build-dependencies]
 lalrpop = "0.19"
 
-[dev-dependencies]
-spectral = "0.6.0"
-
 [features]
 symbols = []

--- a/psqlpack/src/lib.rs
+++ b/psqlpack/src/lib.rs
@@ -14,11 +14,8 @@ extern crate serde;
 extern crate serde_json;
 #[macro_use]
 extern crate slog;
-extern crate slog_stdlog;
-#[cfg(test)]
-#[macro_use]
-extern crate spectral;
 extern crate glob;
+extern crate slog_stdlog;
 extern crate zip;
 
 mod errors;

--- a/psqlpack/src/model/delta.rs
+++ b/psqlpack/src/model/delta.rs
@@ -1418,7 +1418,6 @@ mod tests {
     use crate::Semver;
 
     use slog::{Discard, Drain, Logger};
-    use spectral::prelude::*;
 
     fn empty_logger() -> Logger {
         Logger::root(Discard.fuse(), o!())
@@ -1456,31 +1455,36 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to add
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::AddType(ref ty) => {
-                assert_that!(ty.name).is_equal_to(ast::ObjectName {
-                    schema: Some("public".to_string()),
-                    name: "colors".to_string(),
-                });
+                assert_eq!(
+                    ty.name,
+                    ast::ObjectName {
+                        schema: Some("public".to_string()),
+                        name: "colors".to_string(),
+                    }
+                );
                 let values = match ty.kind {
                     TypeDefinitionKind::Enum(ref values) => values.clone(),
                     ref unknown => panic!("Unknown kind: {}", unknown), // TODO
                 };
-                assert_that!(values).has_length(3);
-                assert_that!(values[0]).is_equal_to("red".to_owned());
-                assert_that!(values[1]).is_equal_to("green".to_owned());
-                assert_that!(values[2]).is_equal_to("blue".to_owned());
+                assert_eq!(values.len(), 3);
+                assert_eq!(values[0], "red");
+                assert_eq!(values[1], "green");
+                assert_eq!(values[2], "blue");
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log))
-            .is_equal_to("CREATE TYPE public.colors AS ENUM (\n  'red',\n  'green',\n  'blue'\n)".to_owned());
+        assert_eq!(
+            change_set[0].to_sql(&log),
+            "CREATE TYPE public.colors AS ENUM (\n  'red',\n  'green',\n  'blue'\n)"
+        );
     }
 
     #[test]
@@ -1506,10 +1510,10 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to add
-        assert_that!(change_set).is_empty();
+        assert!(change_set.is_empty());
     }
 
     #[test]
@@ -1546,22 +1550,25 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to modify the enum with an additional value
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::ModifyType(ty, ref action) => {
-                assert_that!(ty.name).is_equal_to(ast::ObjectName {
-                    schema: Some("public".to_string()),
-                    name: "colors".to_string(),
-                });
+                assert_eq!(
+                    ty.name,
+                    ast::ObjectName {
+                        schema: Some("public".to_string()),
+                        name: "colors".to_string(),
+                    }
+                );
 
                 // Also, match the action
                 match *action {
                     TypeModificationAction::AddEnumValueAfter { ref value, ref after } => {
-                        assert_that!(*value).is_equal_to("black".to_owned());
-                        assert_that!(*after).is_equal_to("blue".to_owned());
+                        assert_eq!(*value, "black");
+                        assert_eq!(*after, "blue");
                     }
                     ref unexpected => panic!("Unexpected enum modification action: {:?}", unexpected),
                 }
@@ -1570,8 +1577,10 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log))
-            .is_equal_to("ALTER TYPE public.colors ADD VALUE 'black' AFTER 'blue'".to_owned());
+        assert_eq!(
+            change_set[0].to_sql(&log),
+            "ALTER TYPE public.colors ADD VALUE 'black' AFTER 'blue'"
+        );
     }
 
     #[test]
@@ -1608,22 +1617,25 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to modify the enum with an additional value
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::ModifyType(ty, ref action) => {
-                assert_that!(ty.name).is_equal_to(ast::ObjectName {
-                    schema: Some("public".to_string()),
-                    name: "colors".to_string(),
-                });
+                assert_eq!(
+                    ty.name,
+                    ast::ObjectName {
+                        schema: Some("public".to_string()),
+                        name: "colors".to_string(),
+                    }
+                );
 
                 // Also, match the action
                 match *action {
                     TypeModificationAction::AddEnumValueBefore { ref value, ref before } => {
-                        assert_that!(*value).is_equal_to("black".to_owned());
-                        assert_that!(*before).is_equal_to("red".to_owned());
+                        assert_eq!(*value, "black");
+                        assert_eq!(*before, "red");
                     }
                     ref unexpected => panic!("Unexpected enum modification action: {:?}", unexpected),
                 }
@@ -1632,8 +1644,10 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log))
-            .is_equal_to("ALTER TYPE public.colors ADD VALUE 'black' BEFORE 'red'".to_owned());
+        assert_eq!(
+            change_set[0].to_sql(&log),
+            "ALTER TYPE public.colors ADD VALUE 'black' BEFORE 'red'"
+        );
     }
 
     #[test]
@@ -1670,22 +1684,25 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to modify the enum with an additional value
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::ModifyType(ty, ref action) => {
-                assert_that!(ty.name).is_equal_to(ast::ObjectName {
-                    schema: Some("public".to_string()),
-                    name: "colors".to_string(),
-                });
+                assert_eq!(
+                    ty.name,
+                    ast::ObjectName {
+                        schema: Some("public".to_string()),
+                        name: "colors".to_string(),
+                    }
+                );
 
                 // Also, match the action
                 match *action {
                     TypeModificationAction::AddEnumValueAfter { ref value, ref after } => {
-                        assert_that!(*value).is_equal_to("black".to_owned());
-                        assert_that!(*after).is_equal_to("green".to_owned());
+                        assert_eq!(*value, "black");
+                        assert_eq!(*after, "green");
                     }
                     ref unexpected => panic!("Unexpected enum modification action: {:?}", unexpected),
                 }
@@ -1694,8 +1711,10 @@ mod tests {
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log))
-            .is_equal_to("ALTER TYPE public.colors ADD VALUE 'black' AFTER 'green'".to_owned());
+        assert_eq!(
+            change_set[0].to_sql(&log),
+            "ALTER TYPE public.colors ADD VALUE 'black' AFTER 'green'"
+        );
     }
 
     #[test]
@@ -1728,23 +1747,26 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to modify the enum with an additional value
-        assert_that!(change_set).has_length(2);
+        assert_eq!(change_set.len(), 2);
 
         // Removals first
         match change_set[0] {
             ChangeInstruction::ModifyType(ty, ref action) => {
-                assert_that!(ty.name).is_equal_to(ast::ObjectName {
-                    schema: Some("public".to_string()),
-                    name: "colors".to_string(),
-                });
+                assert_eq!(
+                    ty.name,
+                    ast::ObjectName {
+                        schema: Some("public".to_string()),
+                        name: "colors".to_string(),
+                    }
+                );
 
                 // Also, match the action
                 match *action {
                     TypeModificationAction::RemoveEnumValue { ref value } => {
-                        assert_that!(*value).is_equal_to("red".to_owned());
+                        assert_eq!(*value, "red");
                     }
                     ref unexpected => panic!("Unexpected enum modification action: {:?}", unexpected),
                 }
@@ -1752,26 +1774,29 @@ mod tests {
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log)).is_equal_to(
+        assert_eq!(
+            change_set[0].to_sql(&log),
             "DELETE FROM pg_enum \
              WHERE enumlabel='red' AND \
-             enumtypid=(SELECT oid FROM pg_type WHERE nspname='public' AND typname='colors')"
-                .to_owned(),
+             enumtypid=(SELECT oid FROM pg_type WHERE nspname='public' AND typname='colors')",
         );
 
         // Additions second
         match change_set[1] {
             ChangeInstruction::ModifyType(ty, ref action) => {
-                assert_that!(ty.name).is_equal_to(ast::ObjectName {
-                    schema: Some("public".to_string()),
-                    name: "colors".to_string(),
-                });
+                assert_eq!(
+                    ty.name,
+                    ast::ObjectName {
+                        schema: Some("public".to_string()),
+                        name: "colors".to_string(),
+                    }
+                );
 
                 // Also, match the action
                 match *action {
                     TypeModificationAction::AddEnumValueBefore { ref value, ref before } => {
-                        assert_that!(*value).is_equal_to("black".to_owned());
-                        assert_that!(*before).is_equal_to("green".to_owned());
+                        assert_eq!(value, "black");
+                        assert_eq!(before, "green");
                     }
                     ref unexpected => panic!("Unexpected enum modification action: {:?}", unexpected),
                 }
@@ -1779,8 +1804,10 @@ mod tests {
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
         // Check the SQL generation
-        assert_that!(change_set[1].to_sql(&log))
-            .is_equal_to("ALTER TYPE public.colors ADD VALUE 'black' BEFORE 'green'".to_owned());
+        assert_eq!(
+            change_set[1].to_sql(&log),
+            "ALTER TYPE public.colors ADD VALUE 'black' BEFORE 'green'"
+        );
     }
 
     #[test]
@@ -1812,7 +1839,7 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_err();
+        assert!(result.is_err());
         match result.err().unwrap() {
             PsqlpackError(PublishUnsafeOperationError(_), _) => {}
             unexpected => panic!("Expected unsafe operation error however saw {:?}", unexpected),
@@ -1849,23 +1876,26 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to modify the enum with an additional value
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
 
         // Removals first
         match change_set[0] {
             ChangeInstruction::ModifyType(ty, ref action) => {
-                assert_that!(ty.name).is_equal_to(ast::ObjectName {
-                    schema: Some("public".to_string()),
-                    name: "colors".to_string(),
-                });
+                assert_eq!(
+                    ty.name,
+                    ast::ObjectName {
+                        schema: Some("public".to_string()),
+                        name: "colors".to_string(),
+                    }
+                );
 
                 // Also, match the action
                 match *action {
                     TypeModificationAction::RemoveEnumValue { ref value } => {
-                        assert_that!(*value).is_equal_to("red".to_owned());
+                        assert_eq!(*value, "red");
                     }
                     ref unexpected => panic!("Unexpected enum modification action: {:?}", unexpected),
                 }
@@ -1873,11 +1903,11 @@ mod tests {
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log)).is_equal_to(
+        assert_eq!(
+            change_set[0].to_sql(&log),
             "DELETE FROM pg_enum \
              WHERE enumlabel='red' AND \
-             enumtypid=(SELECT oid FROM pg_type WHERE nspname='public' AND typname='colors')"
-                .to_owned(),
+             enumtypid=(SELECT oid FROM pg_type WHERE nspname='public' AND typname='colors')",
         );
     }
 
@@ -1930,30 +1960,30 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to create a new table
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::AddTable(ref table) => {
-                assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
-                assert_that!(table.columns).has_length(3);
-                assert_that!(table.columns[0].name).is_equal_to("id".to_owned());
-                assert_that!(table.columns[1].name).is_equal_to("company_id".to_owned());
-                assert_that!(table.columns[2].name).is_equal_to("first_name".to_owned());
-                assert_that!(table.constraints).is_empty();
+                assert_eq!(table.name.to_string(), "my.contacts");
+                assert_eq!(table.columns.len(), 3);
+                assert_eq!(table.columns[0].name, "id");
+                assert_eq!(table.columns[1].name, "company_id");
+                assert_eq!(table.columns[2].name, "first_name");
+                assert!(table.constraints.is_empty());
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log)).is_equal_to(
+        assert_eq!(
+            change_set[0].to_sql(&log),
             "CREATE TABLE my.contacts (\n\
              \tid serial NOT NULL PRIMARY KEY,\n\
              \tcompany_id bigint NOT NULL,\n\
              \tfirst_name varchar(100) NOT NULL\n\
              )"
-            .to_owned(),
         );
     }
 
@@ -1986,7 +2016,7 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(change_set).is_empty();
+        assert!(change_set.is_empty());
 
         // Now we check with a linked column
         let result = LinkedColumn {
@@ -2000,24 +2030,28 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to create a new table
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::AddColumn(ref table, ref column) => {
-                assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
-                assert_that!(column.name).is_equal_to("last_name".to_owned());
-                assert_that!(column.sql_type)
-                    .is_equal_to(SqlType::Simple(SimpleSqlType::VariableLengthString(100), None));
-                assert_that!(column.constraints).has_length(1);
+                assert_eq!(table.name.to_string(), "my.contacts");
+                assert_eq!(column.name, "last_name");
+                assert_eq!(
+                    column.sql_type,
+                    SqlType::Simple(SimpleSqlType::VariableLengthString(100), None)
+                );
+                assert_eq!(column.constraints.len(), 1);
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log))
-            .is_equal_to("ALTER TABLE my.contacts ADD COLUMN last_name varchar(100) NOT NULL".to_owned());
+        assert_eq!(
+            change_set[0].to_sql(&log),
+            "ALTER TABLE my.contacts ADD COLUMN last_name varchar(100) NOT NULL"
+        );
     }
 
     #[test]
@@ -2056,7 +2090,7 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(change_set).is_empty();
+        assert!(change_set.is_empty());
 
         // Now we check with a linked column
         let result = LinkedColumn {
@@ -2070,24 +2104,28 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to create a new table
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::ModifyColumnType(ref table, ref column) => {
-                assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
-                assert_that!(column.name).is_equal_to("last_name".to_owned());
-                assert_that!(column.sql_type)
-                    .is_equal_to(SqlType::Simple(SimpleSqlType::VariableLengthString(200), None));
-                assert_that!(column.constraints).has_length(1);
+                assert_eq!(table.name.to_string(), "my.contacts");
+                assert_eq!(column.name, "last_name");
+                assert_eq!(
+                    column.sql_type,
+                    SqlType::Simple(SimpleSqlType::VariableLengthString(200), None)
+                );
+                assert_eq!(column.constraints.len(), 1);
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log))
-            .is_equal_to("ALTER TABLE my.contacts ALTER COLUMN last_name TYPE varchar(200)".to_owned());
+        assert_eq!(
+            change_set[0].to_sql(&log),
+            "ALTER TABLE my.contacts ALTER COLUMN last_name TYPE varchar(200)"
+        );
     }
 
     #[test]
@@ -2121,21 +2159,23 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to create a new table
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::DropColumn(ref table, ref column_name) => {
-                assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
-                assert_that!(*column_name).is_equal_to("last_name".to_owned());
+                assert_eq!(table.name.to_string(), "my.contacts");
+                assert_eq!(column_name, "last_name");
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log))
-            .is_equal_to("ALTER TABLE my.contacts DROP COLUMN last_name".to_owned());
+        assert_eq!(
+            change_set[0].to_sql(&log),
+            "ALTER TABLE my.contacts DROP COLUMN last_name"
+        );
     }
 
     #[test]
@@ -2167,7 +2207,7 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(change_set).is_empty();
+        assert!(change_set.is_empty());
 
         // Now we check with a linked table constraint
         let result = LinkedTableConstraint {
@@ -2181,34 +2221,35 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to add a constraint
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::AddConstraint(ref table, ref constraint) => {
-                assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
+                assert_eq!(table.name.to_string(), "my.contacts");
                 match *constraint {
                     TableConstraint::Primary {
                         name,
                         columns,
                         parameters,
                     } => {
-                        assert_that!(*name).is_equal_to("pk_my_contacts_id".to_owned());
-                        assert_that!(*columns).has_length(1);
-                        assert_that!(columns.iter()).contains("id".to_owned());
-                        assert_that!(*parameters).is_some().has_length(1);
+                        assert_eq!(name, "pk_my_contacts_id");
+                        assert_eq!(columns.len(), 1);
+                        assert!(columns.contains(&"id".to_owned()));
+                        assert!(parameters.is_some());
+                        assert_eq!(parameters.as_ref().unwrap().len(), 1);
                     }
-                    unxpected => panic!("Unexpected constraint: {:?}", unxpected),
+                    unexpected => panic!("Unexpected constraint: {:?}", unexpected),
                 }
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log)).is_equal_to(
+        assert_eq!(
+            change_set[0].to_sql(&log),
             "ALTER TABLE my.contacts\nADD CONSTRAINT pk_my_contacts_id PRIMARY KEY (id) WITH (FILLFACTOR=80)"
-                .to_owned(),
         );
     }
 
@@ -2243,21 +2284,23 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to remove the constraint
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::DropConstraint(ref table, ref name) => {
-                assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
-                assert_that!(*name).is_equal_to("pk_my_contacts_id".to_owned());
+                assert_eq!(table.name.to_string(), "my.contacts");
+                assert_eq!(name, "pk_my_contacts_id");
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log))
-            .is_equal_to("ALTER TABLE my.contacts\nDROP CONSTRAINT pk_my_contacts_id".to_owned());
+        assert_eq!(
+            change_set[0].to_sql(&log),
+            "ALTER TABLE my.contacts\nDROP CONSTRAINT pk_my_contacts_id"
+        );
     }
 
     #[test]
@@ -2296,7 +2339,7 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(change_set).is_empty();
+        assert!(change_set.is_empty());
 
         // Now we check with a linked table constraint
         let result = LinkedTableConstraint {
@@ -2310,43 +2353,46 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // Primary keys cannot be altered, so we drop/create
-        assert_that!(change_set).has_length(2);
+        assert_eq!(change_set.len(), 2);
         match change_set[0] {
             ChangeInstruction::DropConstraint(ref table, ref name) => {
-                assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
-                assert_that!(*name).is_equal_to("pk_my_contacts_id".to_owned());
+                assert_eq!(table.name.to_string(), "my.contacts");
+                assert_eq!(name, "pk_my_contacts_id");
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
         match change_set[1] {
             ChangeInstruction::AddConstraint(ref table, ref constraint) => {
-                assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
+                assert_eq!(table.name.to_string(), "my.contacts");
                 match *constraint {
                     TableConstraint::Primary {
                         name,
                         columns,
                         parameters,
                     } => {
-                        assert_that!(*name).is_equal_to("pk_my_contacts_id".to_owned());
-                        assert_that!(*columns).has_length(1);
-                        assert_that!(columns.iter()).contains("id".to_owned());
-                        assert_that!(*parameters).is_some().has_length(1);
+                        assert_eq!(name, "pk_my_contacts_id");
+                        assert_eq!(columns.len(), 1);
+                        assert!(columns.contains(&"id".to_owned()));
+                        assert!(parameters.is_some());
+                        assert_eq!(parameters.as_ref().unwrap().len(), 1);
                     }
-                    unxpected => panic!("Unexpected constraint: {:?}", unxpected),
+                    unexpected => panic!("Unexpected constraint: {:?}", unexpected),
                 }
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log))
-            .is_equal_to("ALTER TABLE my.contacts\nDROP CONSTRAINT pk_my_contacts_id".to_owned());
-        assert_that!(change_set[1].to_sql(&log)).is_equal_to(
+        assert_eq!(
+            change_set[0].to_sql(&log),
+            "ALTER TABLE my.contacts\nDROP CONSTRAINT pk_my_contacts_id"
+        );
+        assert_eq!(
+            change_set[1].to_sql(&log),
             "ALTER TABLE my.contacts\nADD CONSTRAINT pk_my_contacts_id PRIMARY KEY (id) WITH (FILLFACTOR=80)"
-                .to_owned(),
         );
     }
 
@@ -2388,7 +2434,7 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(change_set).is_empty();
+        assert!(change_set.is_empty());
 
         // Now we check with a linked table constraint
         let result = LinkedTableConstraint {
@@ -2402,13 +2448,13 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to create a new constraint
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::AddConstraint(ref table, ref constraint) => {
-                assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
+                assert_eq!(table.name.to_string(), "my.contacts");
                 match *constraint {
                     TableConstraint::Foreign {
                         name,
@@ -2418,29 +2464,29 @@ mod tests {
                         match_type,
                         events,
                     } => {
-                        assert_that!(*name).is_equal_to("fk_my_contacts_my_companies".to_owned());
-                        assert_that!(*columns).has_length(1);
-                        assert_that!(columns.iter()).contains("company_id".to_owned());
-                        assert_that!(ref_table.to_string()).is_equal_to("my.companies".to_owned());
-                        assert_that!(*ref_columns).has_length(1);
-                        assert_that!(ref_columns.iter()).contains("id".to_owned());
-                        assert_that!(*match_type)
-                            .is_some()
-                            .is_equal_to(ForeignConstraintMatchType::Simple);
-                        assert_that!(*events).is_some().has_length(2); // We test this further below
+                        assert_eq!(name, "fk_my_contacts_my_companies");
+                        assert_eq!(columns.len(), 1);
+                        assert!(columns.contains(&"company_id".to_owned()));
+                        assert_eq!(ref_table.to_string(), "my.companies");
+                        assert_eq!(ref_columns.len(), 1);
+                        assert!(ref_columns.contains(&"id".to_owned()));
+                        assert!(match_type.is_some());
+                        assert_eq!(match_type.as_ref().unwrap(), &ForeignConstraintMatchType::Simple);
+                        assert!(events.is_some());
+                        assert_eq!(events.as_ref().unwrap().len(), 2); // We test this further below
                     }
-                    unxpected => panic!("Unexpected constraint: {:?}", unxpected),
+                    unexpected => panic!("Unexpected constraint: {:?}", unexpected),
                 }
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log)).is_equal_to(
+        assert_eq!(
+            change_set[0].to_sql(&log),
             "ALTER TABLE my.contacts\n\
              ADD CONSTRAINT fk_my_contacts_my_companies FOREIGN KEY (company_id) \
              REFERENCES my.companies (id) MATCH SIMPLE ON UPDATE CASCADE ON DELETE NO ACTION"
-                .to_owned(),
         );
     }
 
@@ -2484,21 +2530,23 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to remove a constraint
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::DropConstraint(ref table, ref name) => {
-                assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
-                assert_that!(*name).is_equal_to("fk_my_contacts_my_companies".to_owned());
+                assert_eq!(table.name.to_string(), "my.contacts");
+                assert_eq!(name, "fk_my_contacts_my_companies");
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log))
-            .is_equal_to("ALTER TABLE my.contacts\nDROP CONSTRAINT fk_my_contacts_my_companies".to_owned());
+        assert_eq!(
+            change_set[0].to_sql(&log),
+            "ALTER TABLE my.contacts\nDROP CONSTRAINT fk_my_contacts_my_companies"
+        );
     }
 
     #[test]
@@ -2555,7 +2603,7 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(change_set).is_empty();
+        assert!(change_set.is_empty());
 
         // Now we check with a linked table constraint
         let result = LinkedTableConstraint {
@@ -2569,20 +2617,20 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // Primary keys cannot be altered, so we drop/create
-        assert_that!(change_set).has_length(2);
+        assert_eq!(change_set.len(), 2);
         match change_set[0] {
             ChangeInstruction::DropConstraint(ref table, ref name) => {
-                assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
-                assert_that!(*name).is_equal_to("fk_my_contacts_my_companies".to_owned());
+                assert_eq!(table.name.to_string(), "my.contacts");
+                assert_eq!(name, "fk_my_contacts_my_companies");
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
         match change_set[1] {
             ChangeInstruction::AddConstraint(ref table, ref constraint) => {
-                assert_that!(table.name.to_string()).is_equal_to("my.contacts".to_owned());
+                assert_eq!(table.name.to_string(), "my.contacts");
                 match *constraint {
                     TableConstraint::Foreign {
                         name,
@@ -2592,31 +2640,33 @@ mod tests {
                         match_type,
                         events,
                     } => {
-                        assert_that!(*name).is_equal_to("fk_my_contacts_my_companies".to_owned());
-                        assert_that!(*columns).has_length(1);
-                        assert_that!(columns.iter()).contains("company_id".to_owned());
-                        assert_that!(ref_table.to_string()).is_equal_to("my.companies".to_owned());
-                        assert_that!(*ref_columns).has_length(1);
-                        assert_that!(ref_columns.iter()).contains("id".to_owned());
-                        assert_that!(*match_type)
-                            .is_some()
-                            .is_equal_to(ForeignConstraintMatchType::Simple);
-                        assert_that!(*events).is_some().has_length(2); // We test this further below
+                        assert_eq!(*name, "fk_my_contacts_my_companies");
+                        assert_eq!(columns.len(), 1);
+                        assert!(columns.contains(&"company_id".to_owned()));
+                        assert_eq!(ref_table.to_string(), "my.companies");
+                        assert_eq!(ref_columns.len(), 1);
+                        assert!(ref_columns.contains(&"id".to_owned()));
+                        assert!(match_type.is_some());
+                        assert_eq!(match_type.as_ref().unwrap(), &ForeignConstraintMatchType::Simple);
+                        assert!(events.is_some());
+                        assert_eq!(events.as_ref().unwrap().len(), 2); // We test this further below
                     }
-                    unxpected => panic!("Unexpected constraint: {:?}", unxpected),
+                    unexpected => panic!("Unexpected constraint: {:?}", unexpected),
                 }
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log))
-            .is_equal_to("ALTER TABLE my.contacts\nDROP CONSTRAINT fk_my_contacts_my_companies".to_owned());
-        assert_that!(change_set[1].to_sql(&log)).is_equal_to(
+        assert_eq!(
+            change_set[0].to_sql(&log),
+            "ALTER TABLE my.contacts\nDROP CONSTRAINT fk_my_contacts_my_companies"
+        );
+        assert_eq!(
+            change_set[1].to_sql(&log),
             "ALTER TABLE my.contacts\n\
              ADD CONSTRAINT fk_my_contacts_my_companies FOREIGN KEY (company_id) \
              REFERENCES my.companies (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION"
-                .to_owned(),
         );
     }
 
@@ -2656,24 +2706,24 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have a single instruction to create a new index
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::AddIndex(ref index, concurrently) => {
-                assert_that!(index.name).is_equal_to("idx_contacts_first_name".to_owned());
-                assert_that!(index.table.to_string()).is_equal_to("public.contacts".to_owned());
-                assert_that!(concurrently).is_true();
+                assert_eq!(index.name, "idx_contacts_first_name");
+                assert_eq!(index.table.to_string(), "public.contacts");
+                assert!(concurrently);
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log)).is_equal_to(
+        assert_eq!(
+            change_set[0].to_sql(&log),
             "CREATE UNIQUE INDEX CONCURRENTLY idx_contacts_first_name \
              ON public.contacts USING btree (first_name ASC NULLS LAST)"
-                .to_owned(),
         );
     }
 
@@ -2719,7 +2769,7 @@ mod tests {
             &capabilities,
             &publish_profile,
         );
-        assert_that!(result).is_err();
+        assert!(result.is_err());
         // Now run it again - it should be ok now
         let capabilities = Capabilities {
             server_version: Semver::new(9, 6, None),
@@ -2736,24 +2786,26 @@ mod tests {
             &capabilities,
             &publish_profile,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
         let change_set = match result.unwrap() {
             Delta(c) => c,
         };
 
         // We should have a single instruction to remove an index (first will be use database)
-        assert_that!(change_set).has_length(2);
+        assert_eq!(change_set.len(), 2);
         match change_set[1] {
             ChangeInstruction::DropIndex(ref index, concurrently) => {
-                assert_that!(*index).is_equal_to("public.idx_contacts_first_name".to_owned());
-                assert_that!(concurrently).is_true();
+                assert_eq!(*index, "public.idx_contacts_first_name");
+                assert!(concurrently);
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[1].to_sql(&log))
-            .is_equal_to("DROP INDEX CONCURRENTLY IF EXISTS public.idx_contacts_first_name".to_owned());
+        assert_eq!(
+            change_set[1].to_sql(&log),
+            "DROP INDEX CONCURRENTLY IF EXISTS public.idx_contacts_first_name"
+        );
     }
 
     #[test]
@@ -2814,33 +2866,35 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have two instructions to drop/create a new index
-        assert_that!(change_set).has_length(2);
+        assert_eq!(change_set.len(), 2);
         match change_set[0] {
             ChangeInstruction::DropIndex(ref index_name, concurrently) => {
-                assert_that!(*index_name).is_equal_to("public.idx_contacts_name".to_owned());
-                assert_that!(concurrently).is_true();
+                assert_eq!(*index_name, "public.idx_contacts_name");
+                assert!(concurrently);
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
         match change_set[1] {
             ChangeInstruction::AddIndex(ref index, concurrently) => {
-                assert_that!(index.name).is_equal_to("idx_contacts_name".to_owned());
-                assert_that!(index.table.to_string()).is_equal_to("public.contacts".to_owned());
-                assert_that!(concurrently).is_true();
+                assert_eq!(index.name, "idx_contacts_name");
+                assert_eq!(index.table.to_string(), "public.contacts");
+                assert!(concurrently);
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log))
-            .is_equal_to("DROP INDEX CONCURRENTLY IF EXISTS public.idx_contacts_name".to_owned());
-        assert_that!(change_set[1].to_sql(&log)).is_equal_to(
+        assert_eq!(
+            change_set[0].to_sql(&log),
+            "DROP INDEX CONCURRENTLY IF EXISTS public.idx_contacts_name"
+        );
+        assert_eq!(
+            change_set[1].to_sql(&log),
             "CREATE INDEX CONCURRENTLY idx_contacts_name \
              ON public.contacts USING btree (first_name ASC NULLS LAST, last_name DESC NULLS FIRST)"
-                .to_owned(),
         );
     }
 
@@ -2873,20 +2927,22 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have one instruction to create an extension
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::CreateExtension(ref name, ref _version) => {
-                assert_that!(name).is_equal_to(&"postgis".to_owned());
+                assert_eq!(name, "postgis");
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log))
-            .is_equal_to("CREATE EXTENSION IF NOT EXISTS \"postgis\" WITH VERSION \"2.3.7\"".to_owned());
+        assert_eq!(
+            change_set[0].to_sql(&log),
+            "CREATE EXTENSION IF NOT EXISTS \"postgis\" WITH VERSION \"2.3.7\""
+        );
     }
 
     #[test]
@@ -2918,19 +2974,19 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have one instruction to create an extension
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::CreateExtension(ref name, ref _version) => {
-                assert_that!(name).is_equal_to(&"postgis".to_owned());
+                assert_eq!(name, "postgis");
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log)).is_equal_to("CREATE EXTENSION IF NOT EXISTS \"postgis\"".to_owned());
+        assert_eq!(change_set[0].to_sql(&log), "CREATE EXTENSION IF NOT EXISTS \"postgis\"");
     }
 
     #[test]
@@ -2962,11 +3018,13 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_err();
+        assert!(result.is_err());
 
         let err = result.err().unwrap();
-        let expect = "Publish error: ExtensionRequest postgis version 2.4.7 not available to install".to_owned();
-        assert_that!(format!("{}", err)).is_equal_to(&expect);
+        assert_eq!(
+            format!("{}", err),
+            "Publish error: ExtensionRequest postgis version 2.4.7 not available to install"
+        );
     }
 
     #[test]
@@ -2994,11 +3052,13 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_err();
+        assert!(result.is_err());
 
         let err = result.err().unwrap();
-        let expect = "Publish error: ExtensionRequest postgis version 2.3.7 not available to install".to_owned();
-        assert_that!(format!("{}", err)).is_equal_to(&expect);
+        assert_eq!(
+            format!("{}", err),
+            "Publish error: ExtensionRequest postgis version 2.3.7 not available to install"
+        );
     }
 
     #[test]
@@ -3038,20 +3098,22 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have one instruction to upgrade an extension
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::UpgradeExtension(ref name, ref _version) => {
-                assert_that!(name).is_equal_to(&"postgis".to_owned());
+                assert_eq!(name, "postgis");
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log))
-            .is_equal_to("ALTER EXTENSION \"postgis\" UPDATE TO \"3.8\"".to_owned());
+        assert_eq!(
+            change_set[0].to_sql(&log),
+            "ALTER EXTENSION \"postgis\" UPDATE TO \"3.8\""
+        );
     }
 
     #[test]
@@ -3084,10 +3146,10 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have no instructions
-        assert_that!(change_set).is_empty();
+        assert!(change_set.is_empty());
     }
 
     #[test]
@@ -3128,19 +3190,19 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have one instruction to upgrade an extension
-        assert_that!(change_set).has_length(1);
+        assert_eq!(change_set.len(), 1);
         match change_set[0] {
             ChangeInstruction::UpgradeExtension(ref name, ref _version) => {
-                assert_that!(name).is_equal_to(&"postgis".to_owned());
+                assert_eq!(name, "postgis");
             }
             ref unexpected => panic!("Unexpected instruction type: {:?}", unexpected),
         }
 
         // Check the SQL generation
-        assert_that!(change_set[0].to_sql(&log)).is_equal_to("ALTER EXTENSION \"postgis\" UPDATE".to_owned());
+        assert_eq!(change_set[0].to_sql(&log), "ALTER EXTENSION \"postgis\" UPDATE");
     }
 
     #[test]
@@ -3181,10 +3243,10 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
 
         // We should have no instructions
-        assert_that!(change_set).is_empty();
+        assert!(change_set.is_empty());
     }
 
     #[test]
@@ -3225,12 +3287,9 @@ mod tests {
             &publish_profile,
             &log,
         );
-        assert_that!(result).is_err();
+        assert!(result.is_err());
 
         let err = result.err().unwrap();
-        let expect =
-            "Couldn't publish database due to an unsafe operation: ExtensionRequest postgis version 3.8 is available to upgrade"
-                .to_owned();
-        assert_that!(format!("{}", err)).is_equal_to(&expect);
+        assert_eq!(format!("{}", err), "Couldn't publish database due to an unsafe operation: ExtensionRequest postgis version 3.8 is available to upgrade");
     }
 }

--- a/psqlpack/src/model/package.rs
+++ b/psqlpack/src/model/package.rs
@@ -1086,7 +1086,6 @@ mod tests {
     use crate::sql::{ast, lexer};
 
     use slog::{Discard, Drain, Logger};
-    use spectral::prelude::*;
 
     fn package_sql(sql: &str) -> Package {
         let tokens = match lexer::tokenize_stmt(sql) {
@@ -1120,7 +1119,7 @@ mod tests {
         ($graph:ident,$index:expr,$name:expr) => {
             match $graph[$index] {
                 Node::Table(table) => {
-                    assert_that!(table.name.to_string()).is_equal_to($name.to_owned());
+                    assert_eq!(table.name.to_string(), $name);
                 }
                 _ => panic!("Expected a table at index {}", $index),
             }
@@ -1131,8 +1130,8 @@ mod tests {
         ($graph:ident,$index:expr,$table_name:expr,$column_name:expr) => {
             match $graph[$index] {
                 Node::Column(table, column) => {
-                    assert_that!(table.name.to_string()).is_equal_to($table_name.to_owned());
-                    assert_that!(column.name.to_string()).is_equal_to($column_name.to_owned());
+                    assert_eq!(table.name.to_string(), $table_name);
+                    assert_eq!(column.name.to_string(), $column_name);
                 }
                 _ => panic!("Expected a column at index {}", $index),
             }
@@ -1143,10 +1142,10 @@ mod tests {
         ($graph:ident,$index:expr,$table_name:expr,$constraint_name:expr) => {
             match $graph[$index] {
                 Node::Constraint(table, constraint) => {
-                    assert_that!(table.name.to_string()).is_equal_to($table_name.to_owned());
+                    assert_eq!(table.name.to_string(), $table_name);
                     match *constraint {
                         ast::TableConstraint::Primary { ref name, .. } => {
-                            assert_that!(name.to_string()).is_equal_to($constraint_name.to_owned());
+                            assert_eq!(name.to_string(), $constraint_name);
                         }
                         _ => panic!("Expected a primary key constraint at index {}", $index),
                     }
@@ -1160,10 +1159,10 @@ mod tests {
         ($graph:ident,$index:expr,$table_name:expr,$constraint_name:expr) => {
             match $graph[$index] {
                 Node::Constraint(table, constraint) => {
-                    assert_that!(table.name.to_string()).is_equal_to($table_name.to_owned());
+                    assert_eq!(table.name.to_string(), $table_name);
                     match *constraint {
                         ast::TableConstraint::Foreign { ref name, .. } => {
-                            assert_that!(name.to_string()).is_equal_to($constraint_name.to_owned());
+                            assert_eq!(name.to_string(), $constraint_name);
                         }
                         _ => panic!("Expected a foreign key constraint at index {}", $index),
                     }
@@ -1180,24 +1179,23 @@ mod tests {
 
         // Pre-condition checks
         {
-            assert_that!(package.schemas).is_empty();
-            assert_that!(package.tables).has_length(1);
+            assert!(package.schemas.is_empty());
+            assert_eq!(package.tables.len(), 1);
             let table = &package.tables[0];
-            assert_that!(table.name.schema).is_none();
-            assert_that!(table.name.name).is_equal_to("hello_world".to_owned());
+            assert!(table.name.schema.is_none());
+            assert_eq!(table.name.name, "hello_world");
         }
 
         // Set the defaults and assert again
         package.set_defaults(&project);
-        assert_that!(package.schemas).has_length(1);
-        assert_that!(package.tables).has_length(1);
+        assert_eq!(package.schemas.len(), 1);
+        assert_eq!(package.tables.len(), 1);
         let schema = &package.schemas[0];
-        assert_that!(schema.name).is_equal_to("public".to_owned());
+        assert_eq!(schema.name, "public");
         let table = &package.tables[0];
-        assert_that!(table.name.schema)
-            .is_some()
-            .is_equal_to("public".to_owned());
-        assert_that!(table.name.name).is_equal_to("hello_world".to_owned());
+        assert!(table.name.schema.is_some());
+        assert_eq!(table.name.schema.as_ref().unwrap(), "public");
+        assert_eq!(table.name.name, "hello_world");
     }
 
     #[test]
@@ -1207,38 +1205,35 @@ mod tests {
 
         // Pre-condition checks
         {
-            assert_that!(package.schemas).is_empty();
-            assert_that!(package.indexes).has_length(1);
+            assert!(package.schemas.is_empty());
+            assert_eq!(package.indexes.len(), 1);
             let index = &package.indexes[0];
-            assert_that!(index.table.schema).is_none();
-            assert_that!(index.table.name).is_equal_to("person".to_owned());
-            assert_that!(index.columns).has_length(1);
+            assert!(index.table.schema.is_none());
+            assert_eq!(index.table.name, "person");
+            assert_eq!(index.columns.len(), 1);
             let col = &index.columns[0];
-            assert_that!(col.name).is_equal_to("name".to_owned());
-            assert_that!(col.order).is_none();
-            assert_that!(col.null_position).is_none();
+            assert_eq!(col.name, "name");
+            assert!(col.order.is_none());
+            assert!(col.null_position.is_none());
         }
 
         // Set the defaults and assert again
         package.set_defaults(&project);
-        assert_that!(package.schemas).has_length(1);
-        assert_that!(package.indexes).has_length(1);
+        assert_eq!(package.schemas.len(), 1);
+        assert_eq!(package.indexes.len(), 1);
         let schema = &package.schemas[0];
-        assert_that!(schema.name).is_equal_to("public".to_owned());
+        assert_eq!(schema.name, "public");
         let index = &package.indexes[0];
-        assert_that!(index.table.schema)
-            .is_some()
-            .is_equal_to("public".to_owned());
-        assert_that!(index.table.name).is_equal_to("person".to_owned());
-        assert_that!(index.columns).has_length(1);
+        assert!(index.table.schema.is_some());
+        assert_eq!(index.table.schema.as_ref().unwrap(), "public");
+        assert_eq!(index.table.name, "person");
+        assert_eq!(index.columns.len(), 1);
         let col = &index.columns[0];
-        assert_that!(col.name).is_equal_to("name".to_owned());
-        assert_that!(col.order)
-            .is_some()
-            .is_equal_to(ast::IndexOrder::Ascending);
-        assert_that!(col.null_position)
-            .is_some()
-            .is_equal_to(ast::IndexPosition::Last);
+        assert_eq!(col.name, "name");
+        assert!(col.order.is_some());
+        assert_eq!(col.order.as_ref().unwrap(), &ast::IndexOrder::Ascending);
+        assert!(col.null_position.is_some());
+        assert_eq!(col.null_position.as_ref().unwrap(), &ast::IndexPosition::Last);
     }
 
     #[test]
@@ -1252,8 +1247,9 @@ mod tests {
 
         // Make sure we generated two nodes.
         // We don't generate schema's so it's just going to be table/column
-        assert_that!(graph).is_ok().has_length(2);
+        assert!(graph.is_ok());
         let graph = graph.unwrap();
+        assert_eq!(graph.len(), 2);
         assert_table!(graph, 0, "my.parents");
         assert_column!(graph, 1, "my.parents", "id");
     }
@@ -1271,8 +1267,9 @@ mod tests {
         let graph = package.generate_dependency_graph(&logger);
 
         // Make sure we generated enough nodes (two tables + three columns + one constraint).
-        assert_that!(graph).is_ok().has_length(6);
+        assert!(graph.is_ok());
         let graph = graph.unwrap();
+        assert_eq!(graph.len(), 6);
         assert_table!(graph, 0, "my.parent");
         assert_column!(graph, 1, "my.parent", "id");
         assert_table!(graph, 2, "my.child");
@@ -1301,8 +1298,9 @@ mod tests {
         let graph = package.generate_dependency_graph(&logger);
 
         // Make sure we generated enough nodes (two tables + three columns + three constraints).
-        assert_that!(graph).is_ok().has_length(8);
+        assert!(graph.is_ok());
         let graph = graph.unwrap();
+        assert_eq!(graph.len(), 8);
         assert_table!(graph, 0, "public.transaction");
         assert_column!(graph, 1, "public.transaction", "id");
         assert_column!(graph, 2, "public.transaction", "allocation_id");
@@ -1320,23 +1318,23 @@ mod tests {
         let result = package.validate(&Vec::new());
 
         // `my` schema is missing
-        assert_that!(result).is_err();
+        assert!(result.is_err());
         let validation_errors = match result.err().unwrap() {
             PsqlpackError(ValidationError(errors), _) => errors,
             unexpected => panic!("Expected validation error however saw {:?}", unexpected),
         };
-        assert_that!(validation_errors).has_length(1);
+        assert_eq!(validation_errors.len(), 1);
         match validation_errors[0] {
             ValidationKind::SchemaMissing { ref schema, ref object } => {
-                assert_that!(*schema).is_equal_to("my".to_owned());
-                assert_that!(*object).is_equal_to("items".to_owned());
+                assert_eq!(schema, "my");
+                assert_eq!(object, "items");
             }
             ref unexpected => panic!("Unexpected validation type: {:?}", unexpected),
         }
 
         // Add the schema and try again
         package.schemas.push(ast::SchemaDefinition { name: "my".to_owned() });
-        assert_that!(package.validate(&Vec::new())).is_ok();
+        assert!(package.validate(&Vec::new()).is_ok());
     }
 
     #[test]
@@ -1350,19 +1348,22 @@ mod tests {
         let result = package.validate(&Vec::new());
 
         // `mytype` is missing
-        assert_that!(result).is_err();
+        assert!(result.is_err());
         let validation_errors = match result.err().unwrap() {
             PsqlpackError(ValidationError(errors), _) => errors,
             unexpected => panic!("Expected validation error however saw {:?}", unexpected),
         };
-        assert_that!(validation_errors).has_length(1);
+        assert_eq!(validation_errors.len(), 1);
         match validation_errors[0] {
             ValidationKind::UnknownType { ref ty, ref table } => {
-                assert_that!(*ty).is_equal_to(ast::ObjectName {
-                    schema: Some("public".to_string()),
-                    name: "mytype".to_string(),
-                });
-                assert_that!(*table).is_equal_to("my.items".to_owned());
+                assert_eq!(
+                    *ty,
+                    ast::ObjectName {
+                        schema: Some("public".to_string()),
+                        name: "mytype".to_string(),
+                    }
+                );
+                assert_eq!(table, "my.items");
             }
             ref unexpected => panic!("Unexpected validation type: {:?}", unexpected),
         }
@@ -1375,7 +1376,7 @@ mod tests {
             },
             kind: ast::TypeDefinitionKind::Enum(Vec::new()),
         });
-        assert_that!(package.validate(&Vec::new())).is_ok();
+        assert!(package.validate(&Vec::new()).is_ok());
     }
 
     #[test]
@@ -1390,19 +1391,19 @@ mod tests {
         let result = package.validate(&Vec::new());
 
         // `my.parent` does not exist
-        assert_that!(result).is_err();
+        assert!(result.is_err());
         let validation_errors = match result.err().unwrap() {
             PsqlpackError(ValidationError(errors), _) => errors,
             unexpected => panic!("Expected validation error however saw {:?}", unexpected),
         };
-        assert_that!(validation_errors).has_length(1);
+        assert_eq!(validation_errors.len(), 1);
         match validation_errors[0] {
             ValidationKind::TableConstraintInvalidReferenceTable {
                 ref constraint,
                 ref table,
             } => {
-                assert_that!(*constraint).is_equal_to("fk_parent_child".to_owned());
-                assert_that!(*table).is_equal_to("my.parent".to_owned());
+                assert_eq!(constraint, "fk_parent_child");
+                assert_eq!(table, "my.parent");
             }
             ref unexpected => panic!("Unexpected validation type: {:?}", unexpected),
         }
@@ -1420,7 +1421,7 @@ mod tests {
             }],
             constraints: Vec::new(),
         });
-        assert_that!(package.validate(&Vec::new())).is_ok();
+        assert!(package.validate(&Vec::new()).is_ok());
     }
 
     #[test]
@@ -1436,22 +1437,22 @@ mod tests {
         let result = package.validate(&Vec::new());
 
         // Column `parent_id` is invalid
-        assert_that!(result).is_err();
+        assert!(result.is_err());
         let validation_errors = match result.err().unwrap() {
             PsqlpackError(ValidationError(errors), _) => errors,
             unexpected => panic!("Expected validation error however saw {:?}", unexpected),
         };
-        assert_that!(validation_errors).has_length(1);
+        assert_eq!(validation_errors.len(), 1);
         match validation_errors[0] {
             ValidationKind::TableConstraintInvalidReferenceColumns {
                 ref constraint,
                 ref table,
                 ref columns,
             } => {
-                assert_that!(*constraint).is_equal_to("fk_parent_child".to_owned());
-                assert_that!(*table).is_equal_to("my.parent".to_owned());
-                assert_that!(*columns).has_length(1);
-                assert_that!(columns[0]).is_equal_to("parent_id".to_owned());
+                assert_eq!(constraint, "fk_parent_child");
+                assert_eq!(table, "my.parent");
+                assert_eq!(columns.len(), 1);
+                assert_eq!(columns[0], "parent_id");
             }
             ref unexpected => panic!("Unexpected validation type: {:?}", unexpected),
         }
@@ -1465,7 +1466,7 @@ mod tests {
                 constraints: Vec::new(),
             });
         }
-        assert_that!(package.validate(&Vec::new())).is_ok();
+        assert!(package.validate(&Vec::new()).is_ok());
     }
 
     #[test]
@@ -1481,20 +1482,20 @@ mod tests {
         let result = package.validate(&Vec::new());
 
         // Column `par_id` is invalid
-        assert_that!(result).is_err();
+        assert!(result.is_err());
         let validation_errors = match result.err().unwrap() {
             PsqlpackError(ValidationError(errors), _) => errors,
             unexpected => panic!("Expected validation error however saw {:?}", unexpected),
         };
-        assert_that!(validation_errors).has_length(1);
+        assert_eq!(validation_errors.len(), 1);
         match validation_errors[0] {
             ValidationKind::TableConstraintInvalidSourceColumns {
                 ref constraint,
                 ref columns,
             } => {
-                assert_that!(*constraint).is_equal_to("fk_parent_child".to_owned());
-                assert_that!(*columns).has_length(1);
-                assert_that!(columns[0]).is_equal_to("par_id".to_owned());
+                assert_eq!(constraint, "fk_parent_child");
+                assert_eq!(columns.len(), 1);
+                assert_eq!(columns[0], "par_id");
             }
             ref unexpected => panic!("Unexpected validation type: {:?}", unexpected),
         }
@@ -1508,7 +1509,7 @@ mod tests {
                 constraints: Vec::new(),
             });
         }
-        assert_that!(package.validate(&Vec::new())).is_ok();
+        assert!(package.validate(&Vec::new()).is_ok());
     }
 
     #[test]
@@ -1521,16 +1522,16 @@ mod tests {
         let result = package.validate(&Vec::new());
 
         // `my.company` does not exist
-        assert_that!(result).is_err();
+        assert!(result.is_err());
         let validation_errors = match result.err().unwrap() {
             PsqlpackError(ValidationError(errors), _) => errors,
             unexpected => panic!("Expected validation error however saw {:?}", unexpected),
         };
-        assert_that!(validation_errors).has_length(1);
+        assert_eq!(validation_errors.len(), 1);
         match validation_errors[0] {
             ValidationKind::IndexInvalidReferenceTable { ref index, ref table } => {
-                assert_that!(*index).is_equal_to("idx_company_name".to_owned());
-                assert_that!(*table).is_equal_to("my.company".to_owned());
+                assert_eq!(index, "idx_company_name");
+                assert_eq!(table, "my.company");
             }
             ref unexpected => panic!("Unexpected validation type: {:?}", unexpected),
         }
@@ -1555,7 +1556,7 @@ mod tests {
             ],
             constraints: Vec::new(),
         });
-        assert_that!(package.validate(&Vec::new())).is_ok();
+        assert!(package.validate(&Vec::new()).is_ok());
     }
 
     #[test]
@@ -1568,22 +1569,22 @@ mod tests {
         let result = package.validate(&Vec::new());
 
         // Column `person.number` is invalid
-        assert_that!(result).is_err();
+        assert!(result.is_err());
         let validation_errors = match result.err().unwrap() {
             PsqlpackError(ValidationError(errors), _) => errors,
             unexpected => panic!("Expected validation error however saw {:?}", unexpected),
         };
-        assert_that!(validation_errors).has_length(1);
+        assert_eq!(validation_errors.len(), 1);
         match validation_errors[0] {
             ValidationKind::IndexInvalidReferenceColumns {
                 ref index,
                 ref table,
                 ref columns,
             } => {
-                assert_that!(*index).is_equal_to("idx_person_number".to_owned());
-                assert_that!(*table).is_equal_to("my.person".to_owned());
-                assert_that!(*columns).has_length(1);
-                assert_that!(columns[0]).is_equal_to("number".to_owned());
+                assert_eq!(index, "idx_person_number");
+                assert_eq!(table, "my.person");
+                assert_eq!(columns.len(), 1);
+                assert_eq!(columns[0], "number");
             }
             ref unexpected => panic!("Unexpected validation type: {:?}", unexpected),
         }
@@ -1597,6 +1598,6 @@ mod tests {
                 constraints: Vec::new(),
             });
         }
-        assert_that!(package.validate(&Vec::new())).is_ok();
+        assert!(package.validate(&Vec::new()).is_ok());
     }
 }

--- a/psqlpack/src/model/profiles.rs
+++ b/psqlpack/src/model/profiles.rs
@@ -150,7 +150,6 @@ impl PublishProfile {
 mod tests {
     use crate::model::Toggle;
     use crate::{PublishProfile, Semver};
-    use spectral::prelude::*;
 
     #[test]
     fn it_can_add_read_a_publish_profile_in_json_format() {
@@ -172,17 +171,17 @@ mod tests {
         "#;
         let publish_profile = PublishProfile::from_reader(DATA.as_bytes());
         let publish_profile = publish_profile.unwrap();
-        assert_that!(publish_profile.version).is_equal_to(Semver::new(1, 0, None));
+        assert_eq!(publish_profile.version, Semver::new(1, 0, None));
         let options = publish_profile.generation_options;
-        assert_that!(options.always_recreate_database).is_false();
-        assert_that!(options.drop_enum_values).is_equal_to(Toggle::Error);
-        assert_that!(options.drop_functions).is_equal_to(Toggle::Error);
-        assert_that!(options.drop_tables).is_equal_to(Toggle::Error);
-        assert_that!(options.drop_columns).is_equal_to(Toggle::Error);
-        assert_that!(options.drop_primary_key_constraints).is_equal_to(Toggle::Error);
-        assert_that!(options.drop_foreign_key_constraints).is_equal_to(Toggle::Allow);
-        assert_that!(options.drop_indexes).is_equal_to(Toggle::Ignore);
-        assert_that!(options.force_concurrent_indexes).is_false();
+        assert!(!options.always_recreate_database);
+        assert_eq!(options.drop_enum_values, Toggle::Error);
+        assert_eq!(options.drop_functions, Toggle::Error);
+        assert_eq!(options.drop_tables, Toggle::Error);
+        assert_eq!(options.drop_columns, Toggle::Error);
+        assert_eq!(options.drop_primary_key_constraints, Toggle::Error);
+        assert_eq!(options.drop_foreign_key_constraints, Toggle::Allow);
+        assert_eq!(options.drop_indexes, Toggle::Ignore);
+        assert!(!options.force_concurrent_indexes);
     }
 
     #[test]
@@ -203,16 +202,16 @@ mod tests {
         "#;
         let publish_profile = PublishProfile::from_reader(DATA.as_bytes());
         let publish_profile = publish_profile.unwrap();
-        assert_that!(publish_profile.version).is_equal_to(Semver::new(1, 0, None));
+        assert_eq!(publish_profile.version, Semver::new(1, 0, None));
         let options = publish_profile.generation_options;
-        assert_that!(options.always_recreate_database).is_false();
-        assert_that!(options.drop_enum_values).is_equal_to(Toggle::Error);
-        assert_that!(options.drop_functions).is_equal_to(Toggle::Error);
-        assert_that!(options.drop_tables).is_equal_to(Toggle::Error);
-        assert_that!(options.drop_columns).is_equal_to(Toggle::Error);
-        assert_that!(options.drop_primary_key_constraints).is_equal_to(Toggle::Error);
-        assert_that!(options.drop_foreign_key_constraints).is_equal_to(Toggle::Allow);
-        assert_that!(options.drop_indexes).is_equal_to(Toggle::Ignore);
-        assert_that!(options.force_concurrent_indexes).is_false();
+        assert!(!options.always_recreate_database);
+        assert_eq!(options.drop_enum_values, Toggle::Error);
+        assert_eq!(options.drop_functions, Toggle::Error);
+        assert_eq!(options.drop_tables, Toggle::Error);
+        assert_eq!(options.drop_columns, Toggle::Error);
+        assert_eq!(options.drop_primary_key_constraints, Toggle::Error);
+        assert_eq!(options.drop_foreign_key_constraints, Toggle::Allow);
+        assert_eq!(options.drop_indexes, Toggle::Ignore);
+        assert!(!options.force_concurrent_indexes);
     }
 }

--- a/psqlpack/src/model/project.rs
+++ b/psqlpack/src/model/project.rs
@@ -329,7 +329,6 @@ mod tests {
 
     use crate::model::project::Project;
     use crate::{Dependency, Semver};
-    use spectral::prelude::*;
     use std::path::Path;
 
     #[test]
@@ -340,15 +339,26 @@ mod tests {
         let result = project.walk_files(&parent);
 
         // Check the expected files were returned
-        assert_that!(result).is_ok().has_length(4);
+        assert!(result.is_ok());
         let result = result.unwrap();
+        assert_eq!(result.len(), 4);
         let result: Vec<&str> = result.iter().map(|x| x.to_str().unwrap()).collect();
-        assert_that!(result).contains_all_of(&vec![
-            &"../samples/simple/public/tables/public.expense_status.sql",
-            &"../samples/simple/public/tables/public.organisation.sql",
-            &"../samples/simple/public/tables/public.tax_table.sql",
-            &"../samples/simple/public/tables/public.vendor.sql",
-        ]);
+        assert!(
+            result.contains(&"../samples/simple/public/tables/public.expense_status.sql"),
+            "expense_status.sql"
+        );
+        assert!(
+            result.contains(&"../samples/simple/public/tables/public.organisation.sql"),
+            "organisation.sql"
+        );
+        assert!(
+            result.contains(&"../samples/simple/public/tables/public.tax_table.sql"),
+            "tax_table.sql"
+        );
+        assert!(
+            result.contains(&"../samples/simple/public/tables/public.vendor.sql"),
+            "vendor.sql"
+        );
     }
 
     #[test]
@@ -369,15 +379,14 @@ mod tests {
         let result = project.walk_files(&parent);
 
         // Check the expected files were returned
-        assert_that!(result).is_ok().has_length(3);
+        assert!(result.is_ok());
         let result = result.unwrap();
+        assert_eq!(result.len(), 3);
         let result: Vec<&str> = result.iter().map(|x| x.to_str().unwrap()).collect();
-        assert_that!(result).does_not_contain(&"../samples/simple/public/tables/public.organisation.sql");
-        assert_that!(result).contains_all_of(&vec![
-            &"../samples/simple/public/tables/public.expense_status.sql",
-            &"../samples/simple/public/tables/public.tax_table.sql",
-            &"../samples/simple/public/tables/public.vendor.sql",
-        ]);
+        assert!(!result.contains(&"../samples/simple/public/tables/public.organisation.sql"));
+        assert!(result.contains(&"../samples/simple/public/tables/public.expense_status.sql"));
+        assert!(result.contains(&"../samples/simple/public/tables/public.tax_table.sql"));
+        assert!(result.contains(&"../samples/simple/public/tables/public.vendor.sql"));
     }
 
     #[test]
@@ -398,13 +407,12 @@ mod tests {
         let result = project.walk_files(&parent);
 
         // Check the expected files were returned
-        assert_that!(result).is_ok();
+        assert!(result.is_ok());
         let result = result.unwrap();
         let result: Vec<&str> = result.iter().map(|x| x.to_str().unwrap()).collect();
-        assert_that!(result)
-            .does_not_contain(&"../samples/complex/geo/functions/fn_do_any_coordinates_fall_inside.sql");
-        assert_that!(result).does_not_contain(&"../samples/complex/geo/tables/states.sql");
-        assert_that!(result).does_not_contain(&"../samples/complex/scripts/seed/geo.states.sql");
+        assert!(!result.contains(&"../samples/complex/geo/functions/fn_do_any_coordinates_fall_inside.sql"));
+        assert!(!result.contains(&"../samples/complex/geo/tables/states.sql"));
+        assert!(!result.contains(&"../samples/complex/scripts/seed/geo.states.sql"));
     }
 
     #[test]
@@ -425,10 +433,11 @@ mod tests {
         let result = project.walk_files(&parent);
 
         // Check the expected files were returned
-        assert_that!(result).is_ok().has_length(1);
+        assert!(result.is_ok());
         let result = result.unwrap();
+        assert_eq!(result.len(), 1);
         let result: Vec<&str> = result.iter().map(|x| x.to_str().unwrap()).collect();
-        assert_that!(result).contains_all_of(&vec![&"../samples/simple/public/tables/public.organisation.sql"]);
+        assert!(result.contains(&"../samples/simple/public/tables/public.organisation.sql"));
     }
 
     #[test]
@@ -457,37 +466,46 @@ mod tests {
         "#;
         let project = Project::from_reader(DATA.as_bytes());
         let project = project.unwrap();
-        assert_that!(project.version).is_equal_to(Semver::new(1, 0, None));
-        assert_that!(project.default_schema).is_equal_to("public".to_owned());
+        assert_eq!(project.version, Semver::new(1, 0, None));
+        assert_eq!(project.default_schema, "public");
 
-        assert_that!(project.pre_deploy_scripts).has_length(1);
-        assert_that!(project.pre_deploy_scripts[0]).is_equal_to("scripts/pre-deploy/drop-something.sql".to_owned());
+        assert_eq!(project.pre_deploy_scripts.len(), 1);
+        assert_eq!(project.pre_deploy_scripts[0], "scripts/pre-deploy/drop-something.sql");
 
-        assert_that!(project.post_deploy_scripts).has_length(2);
-        assert_that!(project.post_deploy_scripts[0]).is_equal_to("scripts/seed/seed1.sql".to_owned());
-        assert_that!(project.post_deploy_scripts[1]).is_equal_to("scripts/seed/seed2.sql".to_owned());
+        assert_eq!(project.post_deploy_scripts.len(), 2);
+        assert_eq!(project.post_deploy_scripts[0], "scripts/seed/seed1.sql");
+        assert_eq!(project.post_deploy_scripts[1], "scripts/seed/seed2.sql");
 
-        assert_that!(project.exclude_globs).is_some();
+        assert!(project.exclude_globs.is_some());
         let exclude_globs = project.exclude_globs.unwrap();
-        assert_that!(exclude_globs).has_length(2);
-        assert_that!(exclude_globs[0]).is_equal_to("**/ex/**/*.sql".to_owned());
-        assert_that!(exclude_globs[1]).is_equal_to("**/ex.*".to_owned());
+        assert_eq!(exclude_globs.len(), 2);
+        assert_eq!(exclude_globs[0], "**/ex/**/*.sql");
+        assert_eq!(exclude_globs[1], "**/ex.*");
 
-        assert_that!(project.extensions).is_some();
+        assert!(project.extensions.is_some());
         let extensions = project.extensions.unwrap();
-        assert_that!(extensions).has_length(3);
-        assert_that!(extensions[0]).is_equal_to(Dependency {
-            name: "postgis".into(),
-            version: None,
-        });
-        assert_that!(extensions[1]).is_equal_to(Dependency {
-            name: "postgis_topology".into(),
-            version: None,
-        });
-        assert_that!(extensions[2]).is_equal_to(Dependency {
-            name: "postgis_tiger_geocoder".into(),
-            version: None,
-        });
+        assert_eq!(extensions.len(), 3);
+        assert_eq!(
+            extensions[0],
+            Dependency {
+                name: "postgis".into(),
+                version: None,
+            }
+        );
+        assert_eq!(
+            extensions[1],
+            Dependency {
+                name: "postgis_topology".into(),
+                version: None,
+            }
+        );
+        assert_eq!(
+            extensions[2],
+            Dependency {
+                name: "postgis_tiger_geocoder".into(),
+                version: None,
+            }
+        );
     }
 
     #[test]
@@ -514,36 +532,45 @@ mod tests {
         "#;
         let project = Project::from_reader(DATA.as_bytes());
         let project = project.unwrap();
-        assert_that!(project.version).is_equal_to(Semver::new(1, 0, None));
-        assert_that!(project.default_schema).is_equal_to("public".to_owned());
+        assert_eq!(project.version, Semver::new(1, 0, None));
+        assert_eq!(project.default_schema, "public");
 
-        assert_that!(project.pre_deploy_scripts).has_length(1);
-        assert_that!(project.pre_deploy_scripts[0]).is_equal_to("scripts/pre-deploy/drop-something.sql".to_owned());
+        assert_eq!(project.pre_deploy_scripts.len(), 1);
+        assert_eq!(project.pre_deploy_scripts[0], "scripts/pre-deploy/drop-something.sql");
 
-        assert_that!(project.post_deploy_scripts).has_length(2);
-        assert_that!(project.post_deploy_scripts[0]).is_equal_to("scripts/seed/seed1.sql".to_owned());
-        assert_that!(project.post_deploy_scripts[1]).is_equal_to("scripts/seed/seed2.sql".to_owned());
+        assert_eq!(project.post_deploy_scripts.len(), 2);
+        assert_eq!(project.post_deploy_scripts[0], "scripts/seed/seed1.sql");
+        assert_eq!(project.post_deploy_scripts[1], "scripts/seed/seed2.sql");
 
-        assert_that!(project.exclude_globs).is_some();
+        assert!(project.exclude_globs.is_some());
         let exclude_globs = project.exclude_globs.unwrap();
-        assert_that!(exclude_globs).has_length(2);
-        assert_that!(exclude_globs[0]).is_equal_to("**/ex/**/*.sql".to_owned());
-        assert_that!(exclude_globs[1]).is_equal_to("**/ex.*".to_owned());
+        assert_eq!(exclude_globs.len(), 2);
+        assert_eq!(exclude_globs[0], "**/ex/**/*.sql");
+        assert_eq!(exclude_globs[1], "**/ex.*");
 
-        assert_that!(project.extensions).is_some();
+        assert!(project.extensions.is_some());
         let extensions = project.extensions.unwrap();
-        assert_that!(extensions).has_length(3);
-        assert_that!(extensions[0]).is_equal_to(Dependency {
-            name: "postgis".into(),
-            version: None,
-        });
-        assert_that!(extensions[1]).is_equal_to(Dependency {
-            name: "postgis_topology".into(),
-            version: None,
-        });
-        assert_that!(extensions[2]).is_equal_to(Dependency {
-            name: "postgis_tiger_geocoder".into(),
-            version: None,
-        });
+        assert_eq!(extensions.len(), 3);
+        assert_eq!(
+            extensions[0],
+            Dependency {
+                name: "postgis".into(),
+                version: None,
+            }
+        );
+        assert_eq!(
+            extensions[1],
+            Dependency {
+                name: "postgis_topology".into(),
+                version: None,
+            }
+        );
+        assert_eq!(
+            extensions[2],
+            Dependency {
+                name: "postgis_tiger_geocoder".into(),
+                version: None,
+            }
+        );
     }
 }

--- a/psqlpack/src/semver.rs
+++ b/psqlpack/src/semver.rs
@@ -143,8 +143,6 @@ mod tests {
     use super::Semver;
     use std::str::FromStr;
 
-    use spectral::prelude::*;
-
     #[test]
     fn it_can_parse_version_strings() {
         let tests = &[
@@ -157,8 +155,8 @@ mod tests {
         ];
         for &(given, expected) in tests {
             let parsed = Semver::from_str(given);
-            assert_that!(parsed).is_ok();
-            assert_that!(parsed.unwrap().to_string()).is_equal_to(expected.to_string());
+            assert!(parsed.is_ok());
+            assert_eq!(parsed.unwrap().to_string(), expected.to_string());
         }
     }
 }

--- a/psqlpack/src/sql/tests.rs
+++ b/psqlpack/src/sql/tests.rs
@@ -2,8 +2,6 @@ use crate::sql::ast::*;
 use crate::sql::lexer;
 use crate::sql::parser::{FunctionArgumentListParser, StatementListParser};
 
-use spectral::prelude::*;
-
 #[test]
 fn it_can_parse_a_basic_function_definition() {
     let sql = "CREATE OR REPLACE FUNCTION index(index int)
@@ -14,30 +12,33 @@ fn it_can_parse_a_basic_function_definition() {
                LANGUAGE SQL;";
 
     let tokens = lexer::tokenize_stmt(sql);
-    assert_that!(tokens).is_ok();
+    assert!(tokens.is_ok());
     let tokens = tokens.unwrap();
 
     let statements = StatementListParser::new().parse(tokens);
-    assert_that!(statements).is_ok();
+    assert!(statements.is_ok());
     let statements = statements.unwrap();
-    assert_that!(statements).has_length(1);
+    assert_eq!(statements.len(), 1);
     let stmt = &statements[0];
 
-    assert_that!(*stmt).is_equal_to(Statement::Function(FunctionDefinition {
-        name: ObjectName {
-            schema: None,
-            name: "index".into(),
-        },
-        arguments: vec![FunctionArgument {
-            mode: None,
-            name: Some("index".into()),
-            sql_type: SqlType::Simple(SimpleSqlType::Integer, None),
-            default: None,
-        }],
-        return_type: FunctionReturnType::SqlType(SqlType::Simple(SimpleSqlType::Integer, None)),
-        body: "SELECT index".into(),
-        language: FunctionLanguage::SQL,
-    }));
+    assert_eq!(
+        *stmt,
+        Statement::Function(FunctionDefinition {
+            name: ObjectName {
+                schema: None,
+                name: "index".into(),
+            },
+            arguments: vec![FunctionArgument {
+                mode: None,
+                name: Some("index".into()),
+                sql_type: SqlType::Simple(SimpleSqlType::Integer, None),
+                default: None,
+            }],
+            return_type: FunctionReturnType::SqlType(SqlType::Simple(SimpleSqlType::Integer, None)),
+            body: "SELECT index".into(),
+            language: FunctionLanguage::SQL,
+        })
+    );
 }
 
 #[test]
@@ -50,25 +51,28 @@ fn it_can_parse_a_function_definition_with_simple_literals() {
                LANGUAGE SQL;";
 
     let tokens = lexer::tokenize_stmt(sql);
-    assert_that!(tokens).is_ok();
+    assert!(tokens.is_ok());
     let tokens = tokens.unwrap();
 
     let statements = StatementListParser::new().parse(tokens);
-    assert_that!(statements).is_ok();
+    assert!(statements.is_ok());
     let statements = statements.unwrap();
-    assert_that!(statements).has_length(1);
+    assert_eq!(statements.len(), 1);
     let stmt = &statements[0];
 
-    assert_that!(*stmt).is_equal_to(Statement::Function(FunctionDefinition {
-        name: ObjectName {
-            schema: Some("public".into()),
-            name: "x".into(),
-        },
-        arguments: Vec::new(),
-        return_type: FunctionReturnType::SqlType(SqlType::Simple(SimpleSqlType::Integer, None)),
-        body: "SELECT 1".into(),
-        language: FunctionLanguage::SQL,
-    }));
+    assert_eq!(
+        *stmt,
+        Statement::Function(FunctionDefinition {
+            name: ObjectName {
+                schema: Some("public".into()),
+                name: "x".into(),
+            },
+            arguments: Vec::new(),
+            return_type: FunctionReturnType::SqlType(SqlType::Simple(SimpleSqlType::Integer, None)),
+            body: "SELECT 1".into(),
+            language: FunctionLanguage::SQL,
+        })
+    );
 }
 
 #[test]
@@ -87,40 +91,43 @@ fn it_can_parse_a_function_definition_returning_table() {
                LANGUAGE SQL;";
 
     let tokens = lexer::tokenize_stmt(sql);
-    assert_that!(tokens).is_ok();
+    assert!(tokens.is_ok());
     let tokens = tokens.unwrap();
 
     let statements = StatementListParser::new().parse(tokens);
-    assert_that!(statements).is_ok();
+    assert!(statements.is_ok());
     let statements = statements.unwrap();
-    assert_that!(statements).has_length(1);
+    assert_eq!(statements.len(), 1);
     let stmt = &statements[0];
 
-    assert_that!(*stmt).is_equal_to(Statement::Function(FunctionDefinition {
-        name: ObjectName {
-            schema: Some("reference_data".into()),
-            name: "fn_countries".into(),
-        },
-        arguments: Vec::new(),
-        return_type: FunctionReturnType::Table(vec![
-            ColumnDefinition {
-                name: "name".into(),
-                sql_type: SqlType::Simple(SimpleSqlType::VariableLengthString(80), None),
-                constraints: Vec::new(),
+    assert_eq!(
+        *stmt,
+        Statement::Function(FunctionDefinition {
+            name: ObjectName {
+                schema: Some("reference_data".into()),
+                name: "fn_countries".into(),
             },
-            ColumnDefinition {
-                name: "iso".into(),
-                sql_type: SqlType::Simple(SimpleSqlType::VariableLengthString(2), None),
-                constraints: Vec::new(),
-            },
-        ]),
-        body: "SELECT countries.name, countries.iso
+            arguments: Vec::new(),
+            return_type: FunctionReturnType::Table(vec![
+                ColumnDefinition {
+                    name: "name".into(),
+                    sql_type: SqlType::Simple(SimpleSqlType::VariableLengthString(80), None),
+                    constraints: Vec::new(),
+                },
+                ColumnDefinition {
+                    name: "iso".into(),
+                    sql_type: SqlType::Simple(SimpleSqlType::VariableLengthString(2), None),
+                    constraints: Vec::new(),
+                },
+            ]),
+            body: "SELECT countries.name, countries.iso
                    FROM reference_data.countries
                    WHERE countries.enabled=true
                    ORDER BY countries.iso"
-            .into(),
-        language: FunctionLanguage::SQL,
-    }));
+                .into(),
+            language: FunctionLanguage::SQL,
+        })
+    );
 }
 
 #[test]
@@ -140,46 +147,49 @@ fn it_can_parse_a_function_definition_with_parameters() {
                LANGUAGE SQL;";
 
     let tokens = lexer::tokenize_stmt(sql);
-    assert_that!(tokens).is_ok();
+    assert!(tokens.is_ok());
     let tokens = tokens.unwrap();
 
     let statements = StatementListParser::new().parse(tokens);
-    assert_that!(statements).is_ok();
+    assert!(statements.is_ok());
     let statements = statements.unwrap();
-    assert_that!(statements).has_length(1);
+    assert_eq!(statements.len(), 1);
     let stmt = &statements[0];
 
-    assert_that!(*stmt).is_equal_to(Statement::Function(FunctionDefinition {
-        name: ObjectName {
-            schema: Some("reference_data".into()),
-            name: "fn_states".into(),
-        },
-        arguments: vec![FunctionArgument {
-            mode: None,
-            name: Some("country".into()),
-            sql_type: SqlType::Simple(SimpleSqlType::VariableLengthString(2), None),
-            default: None,
-        }],
-        return_type: FunctionReturnType::Table(vec![
-            ColumnDefinition {
-                name: "name".into(),
-                sql_type: SqlType::Simple(SimpleSqlType::VariableLengthString(80), None),
-                constraints: Vec::new(),
+    assert_eq!(
+        *stmt,
+        Statement::Function(FunctionDefinition {
+            name: ObjectName {
+                schema: Some("reference_data".into()),
+                name: "fn_states".into(),
             },
-            ColumnDefinition {
-                name: "iso".into(),
-                sql_type: SqlType::Simple(SimpleSqlType::VariableLengthString(10), None),
-                constraints: Vec::new(),
-            },
-        ]),
-        body: "SELECT states.name, states.iso
+            arguments: vec![FunctionArgument {
+                mode: None,
+                name: Some("country".into()),
+                sql_type: SqlType::Simple(SimpleSqlType::VariableLengthString(2), None),
+                default: None,
+            }],
+            return_type: FunctionReturnType::Table(vec![
+                ColumnDefinition {
+                    name: "name".into(),
+                    sql_type: SqlType::Simple(SimpleSqlType::VariableLengthString(80), None),
+                    constraints: Vec::new(),
+                },
+                ColumnDefinition {
+                    name: "iso".into(),
+                    sql_type: SqlType::Simple(SimpleSqlType::VariableLengthString(10), None),
+                    constraints: Vec::new(),
+                },
+            ]),
+            body: "SELECT states.name, states.iso
                    FROM reference_data.states
                    INNER JOIN reference_data.countries ON countries.id=states.country_id
                    WHERE countries.iso = $1 AND countries.enabled=true AND states.enabled=true
                    ORDER BY states.iso"
-            .into(),
-        language: FunctionLanguage::SQL,
-    }));
+                .into(),
+            language: FunctionLanguage::SQL,
+        })
+    );
 }
 
 #[test]
@@ -197,98 +207,101 @@ fn it_can_parse_function_arguments() {
                touched boolean DEFAULT false";
 
     let tokens = lexer::tokenize_body(sql);
-    assert_that!(tokens).is_ok();
+    assert!(tokens.is_ok());
     let tokens = tokens.unwrap();
 
     let arguments = FunctionArgumentListParser::new().parse(tokens);
-    assert_that!(arguments).is_ok();
+    assert!(arguments.is_ok());
     let arguments = arguments.unwrap();
-    assert_that!(arguments).has_length(11);
-    assert_that!(arguments).is_equal_to(vec![
-        FunctionArgument {
-            mode: None,
-            name: Some("geom".into()),
-            sql_type: SqlType::Custom(
-                ObjectName {
-                    schema: None,
-                    name: "geometry".to_string(),
-                },
-                vec![],
-                None,
-            ),
-            default: None,
-        },
-        FunctionArgument {
-            mode: None,
-            name: Some("scalex".into()),
-            sql_type: SqlType::Simple(SimpleSqlType::Double, None),
-            default: None,
-        },
-        FunctionArgument {
-            mode: None,
-            name: Some("scaley".into()),
-            sql_type: SqlType::Simple(SimpleSqlType::Double, None),
-            default: None,
-        },
-        FunctionArgument {
-            mode: None,
-            name: Some("gridx".into()),
-            sql_type: SqlType::Simple(SimpleSqlType::Double, None),
-            default: Some(AnyValue::Null(Some(SqlType::Simple(SimpleSqlType::Double, None)))),
-        },
-        FunctionArgument {
-            mode: None,
-            name: Some("gridy".into()),
-            sql_type: SqlType::Simple(SimpleSqlType::Double, None),
-            default: Some(AnyValue::Null(Some(SqlType::Simple(SimpleSqlType::Double, None)))),
-        },
-        FunctionArgument {
-            mode: None,
-            name: Some("pixeltype".into()),
-            sql_type: SqlType::Simple(SimpleSqlType::Text, Some(1)),
-            default: Some(AnyValue::Array(
-                vec![AnyValue::String(
-                    "8BUI".into(),
-                    Some(SqlType::Simple(SimpleSqlType::Text, None)),
-                )],
-                None,
-            )),
-        },
-        FunctionArgument {
-            mode: None,
-            name: Some("value".into()),
-            sql_type: SqlType::Simple(SimpleSqlType::Double, Some(1)),
-            default: Some(AnyValue::Array(
-                vec![AnyValue::Integer(1, Some(SqlType::Simple(SimpleSqlType::Double, None)))],
-                None,
-            )),
-        },
-        FunctionArgument {
-            mode: None,
-            name: Some("nodataval".into()),
-            sql_type: SqlType::Simple(SimpleSqlType::Double, Some(1)),
-            default: Some(AnyValue::Array(
-                vec![AnyValue::Integer(0, Some(SqlType::Simple(SimpleSqlType::Double, None)))],
-                None,
-            )),
-        },
-        FunctionArgument {
-            mode: None,
-            name: Some("skewx".into()),
-            sql_type: SqlType::Simple(SimpleSqlType::Double, None),
-            default: Some(AnyValue::Integer(0, None)),
-        },
-        FunctionArgument {
-            mode: None,
-            name: Some("skewy".into()),
-            sql_type: SqlType::Simple(SimpleSqlType::Double, None),
-            default: Some(AnyValue::Integer(0, None)),
-        },
-        FunctionArgument {
-            mode: None,
-            name: Some("touched".into()),
-            sql_type: SqlType::Simple(SimpleSqlType::Boolean, None),
-            default: Some(AnyValue::Boolean(false, None)),
-        },
-    ]);
+    assert_eq!(arguments.len(), 11);
+    assert_eq!(
+        arguments,
+        vec![
+            FunctionArgument {
+                mode: None,
+                name: Some("geom".into()),
+                sql_type: SqlType::Custom(
+                    ObjectName {
+                        schema: None,
+                        name: "geometry".to_string(),
+                    },
+                    vec![],
+                    None,
+                ),
+                default: None,
+            },
+            FunctionArgument {
+                mode: None,
+                name: Some("scalex".into()),
+                sql_type: SqlType::Simple(SimpleSqlType::Double, None),
+                default: None,
+            },
+            FunctionArgument {
+                mode: None,
+                name: Some("scaley".into()),
+                sql_type: SqlType::Simple(SimpleSqlType::Double, None),
+                default: None,
+            },
+            FunctionArgument {
+                mode: None,
+                name: Some("gridx".into()),
+                sql_type: SqlType::Simple(SimpleSqlType::Double, None),
+                default: Some(AnyValue::Null(Some(SqlType::Simple(SimpleSqlType::Double, None)))),
+            },
+            FunctionArgument {
+                mode: None,
+                name: Some("gridy".into()),
+                sql_type: SqlType::Simple(SimpleSqlType::Double, None),
+                default: Some(AnyValue::Null(Some(SqlType::Simple(SimpleSqlType::Double, None)))),
+            },
+            FunctionArgument {
+                mode: None,
+                name: Some("pixeltype".into()),
+                sql_type: SqlType::Simple(SimpleSqlType::Text, Some(1)),
+                default: Some(AnyValue::Array(
+                    vec![AnyValue::String(
+                        "8BUI".into(),
+                        Some(SqlType::Simple(SimpleSqlType::Text, None)),
+                    )],
+                    None,
+                )),
+            },
+            FunctionArgument {
+                mode: None,
+                name: Some("value".into()),
+                sql_type: SqlType::Simple(SimpleSqlType::Double, Some(1)),
+                default: Some(AnyValue::Array(
+                    vec![AnyValue::Integer(1, Some(SqlType::Simple(SimpleSqlType::Double, None)))],
+                    None,
+                )),
+            },
+            FunctionArgument {
+                mode: None,
+                name: Some("nodataval".into()),
+                sql_type: SqlType::Simple(SimpleSqlType::Double, Some(1)),
+                default: Some(AnyValue::Array(
+                    vec![AnyValue::Integer(0, Some(SqlType::Simple(SimpleSqlType::Double, None)))],
+                    None,
+                )),
+            },
+            FunctionArgument {
+                mode: None,
+                name: Some("skewx".into()),
+                sql_type: SqlType::Simple(SimpleSqlType::Double, None),
+                default: Some(AnyValue::Integer(0, None)),
+            },
+            FunctionArgument {
+                mode: None,
+                name: Some("skewy".into()),
+                sql_type: SqlType::Simple(SimpleSqlType::Double, None),
+                default: Some(AnyValue::Integer(0, None)),
+            },
+            FunctionArgument {
+                mode: None,
+                name: Some("touched".into()),
+                sql_type: SqlType::Simple(SimpleSqlType::Boolean, None),
+                default: Some(AnyValue::Boolean(false, None)),
+            },
+        ]
+    );
 }

--- a/psqlpack/tests/common/mod.rs
+++ b/psqlpack/tests/common/mod.rs
@@ -100,42 +100,36 @@ macro_rules! assert_simple_package {
         // We don't assert the length of collection's, only that our one's exist
 
         // Assert that the package exists in the expected format
-        //assert_that!($package.schemas).has_length(2);
         assert!(&$package.schemas.iter().any(|s| s.name.eq($namespace)));
         assert!(&$package.schemas.iter().any(|s| s.name.eq("public")));
 
         // Validate the table
-        //assert_that!($package.tables).has_length(1);
         let table = $package
             .tables
             .iter()
             .find(|s| s.name.to_string().eq(&format!("{}.contacts", $namespace)));
-        assert_that!(table).is_some();
+        assert!(table.is_some());
         let table = table.unwrap();
-        assert_that!(table.name.to_string()).is_equal_to(format!("{}.contacts", $namespace));
-        assert_that!(table.columns).named(&"table.columns").has_length(2);
-        assert_that!(table.constraints)
-            .named(&"table.constraints")
-            .has_length(1);
+        assert_eq!(table.name.to_string(), format!("{}.contacts", $namespace));
+        assert_eq!(table.columns.len(), 2);
+        assert_eq!(table.constraints.len(), 1);
 
         // Validate the id column
         let col_id = &table.columns[0];
-        assert_that!(col_id.name).is_equal_to("id".to_string());
-        assert_that!(col_id.sql_type).is_equal_to(SqlType::Simple(SimpleSqlType::Serial, None));
-        assert_that!(col_id.constraints)
-            .named(&"col_id.constraints")
-            .has_length(1);
-        let constraints = col_id.constraints.iter();
-        assert_that!(constraints).contains(ColumnConstraint::NotNull);
+        assert_eq!(col_id.name, "id");
+        assert_eq!(col_id.sql_type, SqlType::Simple(SimpleSqlType::Serial, None));
+        assert_eq!(col_id.constraints.len(), 1);
+        assert!(col_id.constraints.contains(&ColumnConstraint::NotNull));
 
         // Validate the name column
         let col_name = &table.columns[1];
-        assert_that!(col_name.name).is_equal_to("name".to_string());
-        assert_that!(col_name.sql_type).is_equal_to(SqlType::Simple(SimpleSqlType::VariableLengthString(50), None));
-        assert_that!(col_name.constraints)
-            .named(&"col_name.constraints")
-            .has_length(1);
-        assert_that!(col_name.constraints[0]).is_equal_to(ColumnConstraint::NotNull);
+        assert_eq!(col_name.name, "name");
+        assert_eq!(
+            col_name.sql_type,
+            SqlType::Simple(SimpleSqlType::VariableLengthString(50), None)
+        );
+        assert_eq!(col_name.constraints.len(), 1);
+        assert_eq!(col_name.constraints[0], ColumnConstraint::NotNull);
 
         // We can't assert indexes since we share a database but separate by schema.
         // To get around this we'll filter by schema first.
@@ -150,21 +144,20 @@ macro_rules! assert_simple_package {
                 }
             })
             .collect();
-        assert_that!(schema_indexes).named("package.indexes").has_length(1);
+        assert_eq!(schema_indexes.len(), 1);
         let index = &schema_indexes[0];
-        assert_that!(index.name).is_equal_to("idx_contacts_name".to_string());
-        assert_that!(index.table.to_string()).is_equal_to(format!("{}.contacts", $namespace));
-        assert_that!(index.unique).is_false();
-        assert_that!(index.index_type).is_some().is_equal_to(IndexType::BTree);
-        assert_that!(index.storage_parameters).is_none();
-        assert_that!(index.columns).named("index.columns").has_length(1);
+        assert_eq!(index.name, "idx_contacts_name");
+        assert_eq!(index.table.to_string(), format!("{}.contacts", $namespace));
+        assert!(!index.unique);
+        assert!(index.index_type.is_some());
+        assert_eq!(index.index_type.as_ref().unwrap(), &IndexType::BTree);
+        assert!(index.storage_parameters.is_none());
+        assert_eq!(index.columns.len(), 1);
         let index_col = &index.columns[0];
-        assert_that!(index_col.name).is_equal_to("name".to_string());
-        assert_that!(index_col.order)
-            .is_some()
-            .is_equal_to(IndexOrder::Ascending);
-        assert_that!(index_col.null_position)
-            .is_some()
-            .is_equal_to(IndexPosition::Last);
+        assert_eq!(index_col.name, "name");
+        assert!(index_col.order.is_some());
+        assert_eq!(index_col.order.as_ref().unwrap(), &IndexOrder::Ascending);
+        assert!(index_col.null_position.is_some());
+        assert_eq!(index_col.null_position.as_ref().unwrap(), &IndexPosition::Last);
     }};
 }

--- a/psqlpack/tests/publish.rs
+++ b/psqlpack/tests/publish.rs
@@ -1,7 +1,6 @@
 extern crate psqlpack;
 #[macro_use]
 extern crate slog;
-extern crate spectral;
 
 #[macro_use]
 mod common;
@@ -9,7 +8,6 @@ mod common;
 use psqlpack::ast::*;
 use psqlpack::*;
 use slog::{Discard, Drain, Logger};
-use spectral::prelude::*;
 
 macro_rules! publish_package {
     ($db_name:ident, $connection:ident, $package:ident) => {{


### PR DESCRIPTION
Primarily to remove a dependency on `rustc-serialize`. Besides, `spectral` seems like it may be abandoned.